### PR TITLE
Fix cursor resetting to first line on scroll (#60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 ![App icon](app/src/main/res/mipmap-xxhdpi/ic_launcher_round.png)
 
+*The app is not actively developed since I have deviated from Android development in recent years.
+I'll fix critical bugs, but features may not be implemented before a very long time, if ever. 
+Expect one release per year. I will accept and review pull requests though.*
+
 This is a simple Android app for taking notes, like there have been tens of thousands before.
 The app has Material UI, was built following MVVM architecture, uses Dagger and some Jetpack
 components. Download is available on:

--- a/app/src/main/kotlin/com/maltaisn/notes/ui/edit/LinkArrowKeyMovementMethod.java
+++ b/app/src/main/kotlin/com/maltaisn/notes/ui/edit/LinkArrowKeyMovementMethod.java
@@ -259,8 +259,6 @@ public class LinkArrowKeyMovementMethod extends ArrowKeyMovementMethod {
                             buffer.getSpanEnd(link));
                 }
                 return true;
-            } else {
-                Selection.removeSelection(buffer);
             }
         }
 


### PR DESCRIPTION
Previously, every MotionEvent (```ACTION_UP``` or ```ACTION_DOWN```) on anything other than a link would result in a call to ```Selection.removeSelection(buffer)```. This caused the cursor position to be reset. The issue is resolved by removing this call entirely.

I don't see why it would be necessary in the first place. If I have missed any reasons why this is needed, please tell :)