### PR TITLE
Fix launcher shortcuts for note creation (#78)

### DIFF
--- a/app/src/main/kotlin/com/maltaisn/notes/model/entity/NoteType.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/model/entity/NoteType.kt
@@ -20,5 +20,9 @@ import com.maltaisn.notes.model.ValueEnum
 
 enum class NoteType(override val value: Int) : ValueEnum<Int> {
     TEXT(0),
-    LIST(1)
+    LIST(1);
+
+    companion object {
+        fun fromInt(i: Int) = values().first { it.value == i }
+    }
 }

--- a/app/src/main/kotlin/com/maltaisn/notes/ui/edit/EditFragment.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/ui/edit/EditFragment.kt
@@ -94,7 +94,14 @@ class EditFragment : Fragment(), Toolbar.OnMenuItemClickListener, ConfirmDialog.
             viewModel.exit()
         }
 
-        viewModel.start(args.noteId, args.labelId, args.changeReminder)
+        viewModel.start(
+            args.noteId,
+            args.labelId,
+            args.changeReminder,
+            NoteType.fromInt(args.type),
+            args.title,
+            args.content
+        )
 
         // Toolbar
         binding.toolbar.apply {

--- a/app/src/main/kotlin/com/maltaisn/notes/ui/edit/EditViewModel.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/ui/edit/EditViewModel.kt
@@ -215,7 +215,8 @@ class EditViewModel @AssistedInject constructor(
      * @param noteId Can be [Note.NO_ID] to create a new blank note.
      * @param labelId Can be different from [Label.NO_ID] to initially set a label on a new note.
      */
-    fun start(noteId: Long = Note.NO_ID, labelId: Long = Label.NO_ID, changeReminder: Boolean = false) {
+    fun start(noteId: Long = Note.NO_ID, labelId: Long = Label.NO_ID, changeReminder: Boolean = false,
+              type: NoteType = NoteType.TEXT, title: String = "", content: String = "") {
         viewModelScope.launch {
             // If fragment was very briefly destroyed then recreated, it's possible that this job is launched
             // before the job to save the note on fragment destruction is called.
@@ -237,10 +238,12 @@ class EditViewModel @AssistedInject constructor(
             var labels = noteWithLabels?.labels
 
             if (note == null || labels == null) {
-                // Note doesn't exist, create new blank text note.
+                // Note doesn't exist, create new blank note of the corresponding type.
                 // This is the expected path for creating a new note (by passing Note.NO_ID)
                 val date = Date()
-                note = BLANK_NOTE.copy(addedDate = date, lastModifiedDate = date)
+                note = BLANK_NOTE.copy(addedDate = date, lastModifiedDate = date, title = title, content = content)
+                if (type == NoteType.LIST) note = note.asListNote()
+
                 val id = notesRepository.insertNote(note)
                 note = note.copy(id = id)
 

--- a/app/src/main/kotlin/com/maltaisn/notes/ui/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/ui/main/MainActivity.kt
@@ -98,6 +98,14 @@ class MainActivity : AppCompatActivity(), NavController.OnDestinationChangedList
                 null
             })
         }
+
+        viewModel.createNoteEvent.observeEvent(this) { newNoteData ->
+            navController.navigateSafe(NavGraphMainDirections.actionEditNote(
+                type = newNoteData.type.value,
+                title = newNoteData.title,
+                content = newNoteData.content
+            ))
+        }
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/app/src/main/res/navigation/main_nav_graph.xml
+++ b/app/src/main/res/navigation/main_nav_graph.xml
@@ -73,6 +73,21 @@
             android:defaultValue="false"
             app:argType="boolean"
             />
+        <argument
+            android:name="type"
+            android:defaultValue="0"
+            app:argType="integer"
+            />
+        <argument
+            android:name="title"
+            android:defaultValue=""
+            app:argType="string"
+            />
+        <argument
+            android:name="content"
+            android:defaultValue=""
+            app:argType="string"
+            />
     </fragment>
 
     <dialog


### PR DESCRIPTION
This pull request mainly consists of two things:

1. The use of a semaphore to allow for signalling between the two involved coroutines. This resolves the race condition.
2. Some refactoring so that notes are always created the same way, whether from launcher shortcuts or from within the application. This resolves another visual bug. Previously you could see a blank note appear and instantly disappear after creating a note without any content from the launcher shortcuts. All logic related to creating notes is now in ```EditViewModel.kt```, which seems coherent to me.

