### PR TITLE
Fix reminders launcher shortcut (#80)

### DIFF
--- a/app/src/main/kotlin/com/maltaisn/notes/ui/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/ui/main/MainActivity.kt
@@ -40,6 +40,7 @@ import com.maltaisn.notes.sync.databinding.ActivityMainBinding
 import com.maltaisn.notes.ui.SharedViewModel
 import com.maltaisn.notes.ui.navGraphViewModel
 import com.maltaisn.notes.ui.navigation.HomeDestination
+import com.maltaisn.notes.ui.navigation.NavigationViewModel
 import com.maltaisn.notes.ui.observeEvent
 import com.maltaisn.notes.ui.viewModel
 import javax.inject.Inject
@@ -161,6 +162,7 @@ class MainActivity : AppCompatActivity(), NavController.OnDestinationChangedList
                 }
                 INTENT_ACTION_SHOW_REMINDERS -> {
                     // Show reminders screen in HomeFragment. Used by launcher shortcut.
+                    NavigationViewModel.onRemindersShortcut()
                     sharedViewModel.changeHomeDestination(HomeDestination.Reminders)
                 }
             }

--- a/app/src/main/kotlin/com/maltaisn/notes/ui/navigation/NavigationViewModel.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/ui/navigation/NavigationViewModel.kt
@@ -71,13 +71,8 @@ class NavigationViewModel @AssistedInject constructor(
             _navigationItems.value = value
         }
 
-    private var checkedId = 0L
-        set(value) {
-            field = value
-            savedStateHandle[KEY_CHECKED_ID] = value
-        }
-
     init {
+        NavigationViewModel.savedStateHandle = savedStateHandle
         checkedId = savedStateHandle[KEY_CHECKED_ID] ?: ITEM_ID_ACTIVE
         viewModelScope.launch {
             // Navigation items are constant, except for labels.
@@ -251,5 +246,17 @@ class NavigationViewModel @AssistedInject constructor(
 
         private const val KEY_HOME_DESTINATION = "destination"
         private const val KEY_CHECKED_ID = "checkedId"
+
+        private lateinit var savedStateHandle : SavedStateHandle
+        private var checkedId = 0L
+            set(value) {
+                field = value
+                savedStateHandle[KEY_CHECKED_ID] = value
+            }
+
+        fun onRemindersShortcut() {
+            checkedId = ITEM_ID_REMINDERS
+        }
+
     }
 }


### PR DESCRIPTION
This isn't a perfectly elegant solution, but it does work without any issues.

A better way of doing this would have probably been to propagate the information from the `MainActivity` via the `sharedViewModel` to the `NavigationFragment` and from there to the `NavigationViewModel`. This isn't currently feasible, because of the delayed creation of the `sharedViewModel` in the `NavigationFragment`.

I also wasn't able to find an easy way around this problem, so I think this fix is acceptable.