### PR TITLE
Fix title in drawer menu being cut off by status bar (#74)

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -21,7 +21,6 @@
     android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
     tools:context="com.maltaisn.notes.ui.main.MainActivity"
     >
 

--- a/app/src/main/res/layout/item_navigation_top.xml
+++ b/app/src/main/res/layout/item_navigation_top.xml
@@ -21,14 +21,12 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:paddingBottom="8dp"
-    android:paddingTop="16dp"
     >
 
     <TextView
         android:id="@+id/drawer_title_txv"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
         android:text="@string/app_name_short"


### PR DESCRIPTION
Previously the padding above the header in the navigation drawer was fixed at 24dp. This works fine for the default Android status bar size, but breaks when the status bar is larger, for example because of a notch or a hole-punch camera.

The changes in this PR allow for the padding to dynamically adjust to the status bar size.