### PR TITLE
[Improvement] Only clear notification after reminder has been postponed

### DIFF
--- a/app/src/main/kotlin/com/maltaisn/notes/ui/notification/NotificationActivity.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/ui/notification/NotificationActivity.kt
@@ -56,6 +56,11 @@ class NotificationActivity : AppCompatActivity() {
         viewModel.showTimeDialogEvent.observeEvent(this) { date ->
             navController.navigateSafe(NotificationFragmentDirections.actionReminderPostponeTime(date))
         }
+
+        viewModel.clearNotificationEvent.observeEvent(this) { noteId ->
+            NotificationManagerCompat.from(this).cancel(noteId.toInt())
+        }
+
         viewModel.exitEvent.observeEvent(this) {
             finish()
         }
@@ -66,7 +71,6 @@ class NotificationActivity : AppCompatActivity() {
             when (intent.action) {
                 INTENT_ACTION_POSTPONE -> {
                     val noteId = intent.getLongExtra(AlarmReceiver.EXTRA_NOTE_ID, Note.NO_ID)
-                    NotificationManagerCompat.from(this).cancel(noteId.toInt())
                     viewModel.onPostponeClicked(noteId)
                 }
             }

--- a/app/src/main/kotlin/com/maltaisn/notes/ui/notification/NotificationViewModel.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/ui/notification/NotificationViewModel.kt
@@ -58,6 +58,10 @@ class NotificationViewModel @AssistedInject constructor(
     val showTimeDialogEvent: LiveData<Event<Long>>
         get() = _showTimeDialogEvent
 
+    private val _clearNotificationEvent = MutableLiveData<Event<Long>>()
+    val clearNotificationEvent: LiveData<Event<Long>>
+        get() = _clearNotificationEvent
+
     private val _exitEvent = MutableLiveData<Event<Unit>>()
     val exitEvent: LiveData<Event<Unit>>
         get() = _exitEvent
@@ -123,9 +127,11 @@ class NotificationViewModel @AssistedInject constructor(
                     notesRepository.updateNote(newNote)
                     reminderAlarmManager.setNoteReminderAlarm(newNote)
                 }
+                _clearNotificationEvent.send(noteId)
                 _exitEvent.send()
             }
         } else {
+            _clearNotificationEvent.send(noteId)
             _exitEvent.send()
         }
     }


### PR DESCRIPTION
Currently when choosing to postpone a reminder from a notification, the notification is immediately removed. When a user cancels the postponement process, the notification is gone even though it hasn't been postponed.

With the changes in this PR a notification will only be dismissed after the postponement process finished successfully. This makes much more sense in my opinion.