### PR TITLE
[Important] Fix crash due to multiple semaphore releases

### DIFF
--- a/app/src/main/kotlin/com/maltaisn/notes/ui/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/ui/main/MainViewModel.kt
@@ -70,6 +70,13 @@ class MainViewModel @Inject constructor(
             // This shouldn't technically happen, but there have been cases where recurring reminders failed.
             reminderAlarmManager.updateAllAlarms()
 
+            // Check if last added note is blank, in which case delete it.
+            val lastCreatedNote = notesRepository.getLastCreatedNote()
+            if (lastCreatedNote?.isBlank == true) {
+                notesRepository.deleteNote(lastCreatedNote)
+            }
+            _deletionFinishedSignal.release()
+
             // Periodically remove old notes in trash, and auto export if needed.
             while (true) {
                 notesRepository.deleteOldNotesInTrash()
@@ -88,12 +95,7 @@ class MainViewModel @Inject constructor(
 
     fun onStart() {
         viewModelScope.launch {
-            // Check if last added note is blank, in which case delete it.
-            val lastCreatedNote = notesRepository.getLastCreatedNote()
-            if (lastCreatedNote?.isBlank == true) {
-                notesRepository.deleteNote(lastCreatedNote)
-            }
-            _deletionFinishedSignal.release()
+            notesRepository.deleteOldNotesInTrash()
         }
     }
 


### PR DESCRIPTION
The code for deleting blank notes was moved into the `onStart` method in my fix for the note shortcuts. This doesn't make much sense, because `onStart` is going to be called whenever the MainActivity is reopened after being in the background.

As a result of this, the `_deletionFinishedSignal` is being released multiple times, even though the maximum number of permits is set to 1. This causes the app to crash.

Moving the code back to `init` (where it was in the first place) makes sure that the signal is only released once during the viewmodels lifecycle.