### PR TITLE
Update note list after changing layout mode

### DIFF
--- a/app/src/main/kotlin/com/maltaisn/notes/ui/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/ui/home/HomeViewModel.kt
@@ -140,6 +140,11 @@ class HomeViewModel @AssistedInject constructor(
         updateNoteList()
     }
 
+    override fun onListLayoutModeChanged() {
+        // Updating the list layout mode doesn't trigger the database flow => Update manually.
+        updateNoteList()
+    }
+
     /** When user clicks on empty trash. */
     fun emptyTrashPre() {
         if (listItems.isNotEmpty()) {

--- a/app/src/main/kotlin/com/maltaisn/notes/ui/note/NoteViewModel.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/ui/note/NoteViewModel.kt
@@ -215,6 +215,8 @@ abstract class NoteViewModel(
         _showLabelsFragmentEvent.send(selectedNoteIds.toList())
     }
 
+    protected open fun onListLayoutModeChanged(){}
+
     fun toggleListLayoutMode() {
         val mode = when (_listLayoutMode.value!!) {
             NoteListLayoutMode.LIST -> NoteListLayoutMode.GRID
@@ -222,6 +224,8 @@ abstract class NoteViewModel(
         }
         _listLayoutMode.value = mode
         prefs.listLayoutMode = mode
+
+        onListLayoutModeChanged()
     }
 
     fun moveSelectedNotes() {


### PR DESCRIPTION
The user is able to set different values for the amount of preview lines to be shown depending on the layout mode (grid / list).

When the user changes between list and grid mode the amount of preview lines shown doesn't change, because the NoteList isn't updated. The different amount of preview lines only takes effect on the next database change.

With this PR the issue is fixed by manually calling `updateNoteList()` after changing the list layout mode, similar to how it is handled after changing the sort mode.