### PR TITLE
Small usability improvement regarding reminders

### DIFF
--- a/app/src/main/kotlin/com/maltaisn/notes/ui/reminder/ReminderViewModel.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/ui/reminder/ReminderViewModel.kt
@@ -130,7 +130,7 @@ class ReminderViewModel @AssistedInject constructor(
             }
 
             if (reminder != null) {
-                date = reminder.start.time
+                date = reminder.next.time
                 recurrence = reminder.recurrence ?: Recurrence.DOES_NOT_REPEAT
             } else {
                 // Check preset hours for today


### PR DESCRIPTION
When editing an existing reminder, the ReminderDialog opens with the `reminder.start.time` preselected. This doesn't seem to be the best solution usability-wise, especially when considering reminders which have been postponed (maybe even multiple times). The ReminderDialog is always going to show the inital date of the reminder, instead of the next occurrence.

In my opinion, it would make much more sense to instead show the `reminder.next.time` here, since that is the value the user wants to change.