### PR TITLE
Use correct MaterialAlertDialog style to avoid large insets

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -85,7 +85,7 @@
     </style>
 
     <style name="MaterialAlertDialogThemeOverlay" parent="ThemeOverlay.Material3.MaterialAlertDialog">
-        <item name="alertDialogStyle">@style/MaterialAlertDialog.Material3</item>
+        <item name="alertDialogStyle">@style/MaterialAlertDialogStyle</item>
     </style>
 
     <style name="SearchViewThemeOverlay">


### PR DESCRIPTION
While replacing styles with their Material 3 counterpart, I accidentally used the default alert dialog style with incredibly large vertical insets instead of your custom version. This resulted in the dialog being pretty much unusable on smaller screens.