### PR TITLE
Implement Encrypted Data Exports

### DIFF
--- a/app/src/androidTest/kotlin/com/maltaisn/notes/model/DefaultJsonManagerTest.kt
+++ b/app/src/androidTest/kotlin/com/maltaisn/notes/model/DefaultJsonManagerTest.kt
@@ -982,4 +982,114 @@ class DefaultJsonManagerTest {
 "path":"M10,10h10v10h-10Z"}},"data":"data"}
         """.trim().replace("\n", "")))
     }
+
+    @Test
+    fun testMalformedJsonImport() = runBlocking {
+        val key = encryptionSetup()
+
+        @Language("JSON") val jsonData = """{
+  "notesData": {
+    "version": 3,
+    "notes": {
+      "1": {
+        "type": 0,
+        "title": "note",
+        "content": "content",
+        "metadata": "{\"type\":\"blank\"}",
+        "added": "2020-01-01T00:00:00.000Z",
+        "modified": "2020-02-01T00:00:00.000Z",
+        "status": 0,
+        "pinned": 2,
+        "reminder": {
+          "start": "2020-03-01T00:00:00.000Z",
+          "recurrence": "RRULE:FREQ=DAILY",
+          "next": "2020-03-02T00:00:00.000Z",
+          "count": 1,
+          "done": false
+        },
+        "labels": [1, 10]
+      },
+      "9": {
+        "type": 1,
+        "title": "list",
+        "content": "item 1\nitem 2",
+        "metadata": "{\"type\":\"list\",\"checked\":[false,true]}",
+        "added": "2019-01-01T00:00:00.000Z",
+        "modified": "2019-02-01T00:00:00.000Z",
+        "status": 1,
+        "pinned": 0,
+        "labels": [1, 3]
+      }
+    },
+    "labels": {
+      "1": {"name": "label0", "hidden": true},
+      "3": {"name": "label1"},
+      "10": {"name": "label2"}
+    }
+  },
+  "encryptedNotesData": {
+    "salt": "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI",
+    "nonce":"B+kFILwu8GLF1noQ",
+    "ciphertext":"DwSQ5XQfkqTjhJf58JbrDZAMLhGQfnYWS4zWcrXwkkvQDAlwmE77vyatw1xem/iKqCk2oq24c1+tlOSXEiczT1JY12W6YiLN9o9v3xkYYhIrNuPTSMgtG2n8BoEpvop6Wa1ZJNlq323WnoDvlBzOUovmyzomCqrlQ8+d6xgpfBi2YPDtg+QRpUg0mCz9CBBDQuDTMdWg0UD+AucChEKwXaG0VRAKPtRFgf/qALeC4r8oPwsS3UnLsLELZGWauG8QUl7lGUzR0Ayqruk7PaEG4tOHuN3jcPBwOZHKwDZUti/Ybzn4ClKuBN2gFpTqsSYM8vhpBDz+iJ7fwLiuLAX6yvJLwiex4TACi/ZvcNTjxk2mhSaqwObbY09CbGvYgPb20N+PGdOxSxoz1LnFT6lH0XqUEgjDcIR9av8yNWx41sWNBn9Q3i43zrRe19ygzGCAgU/defKtF7pA27f905UOKY2182qqxtUIBd82Bicgd2wt3j6t7/3o9neZTawGg03pyGQt+u1S6OEt3rcmpjwEr+9PG8alCkqHQEBjqPlpSCU0aBDCV0J01Ck6MTE+qAXYEYjHdCgVpvoQ96MNGEJl3ngkhweZcF+j+Y30LG4SnGHeym18m9yzuYtOm3D6nJ0AMiM/0cB1Qkaes8Naxl/Uesusc41000Y17qNBqhbMy16KEERw3xwnzdKlfE4rSo6L/o8XLolPpHvECmQR3VPZX835O+dAilHtThqYpBMU4AktJBf1ywvH2wNoiDWYGsuTpgZ5C97kJfvk0TF7bAPQtG/KiJxDy9G/OMGsHk3D9m8x5yhvdyw5r2+N5nD/DqY0bVsyqg7+FFzD+mPk60v29PuoBautxkqyoHhkQlEIM+Z6/D6eNO6hz50+SkplJVT8f0bURMmRPcKdVaaX/1yH5ztiO3WZsyIuRpx9cCTjgX51bGuvs1gveEjkw4f/squCem/XD0GBxFoOQjIfeVs5PXsgqiSCCSMjwF1sHY71dfBbTNAiR2PsK47LlrPMsrTJBkKqZptHZy+R+u1sZ9TL/I1kvqP0yoncAPUvzcTANzPyWY1zZL3Qrv5kB/5GtNwDJ33oblHfz/MU6vE/lR5sdo1y/tU5WVLz1OC3VL15h37w0dbgcsFvSZD/pGcyCW4OVYHpIXivnO+VXZmDzjBPnap35PAa5ggRjNkgGtaU8g9NGy4xjq9bLKPvKPK+U8moIbCOQYxENEsUJBjWf/X/r+aXLFoddEVOc/DYLoBTb24O95pi5SxLLCbEcKTmfnYL4iKCsMIMaNXMPM16DBOif4BhyUH1oZZz/E4swyhe3J8vxhUPqwI2njQ"
+  }
+}
+        """.trim().replace("\n", "")
+        assertEquals(ImportResult.BAD_FORMAT, jsonManager.importJsonData(jsonData, importKey = key))
+
+        @Language("JSON") val jsonData2 = """{
+  "notesData": {
+    "version": 3,
+    "notes": {
+      "1": {
+        "type": 0,
+        "title": "note",
+        "content": "content",
+        "metadata": "{\"type\":\"blank\"}",
+        "added": "2020-01-01T00:00:00.000Z",
+        "modified": "2020-02-01T00:00:00.000Z",
+        "status": 0,
+        "pinned": 2,
+        "reminder": {
+          "start": "2020-03-01T00:00:00.000Z",
+          "recurrence": "RRULE:FREQ=DAILY",
+          "next": "2020-03-02T00:00:00.000Z",
+          "count": 1,
+          "done": false
+        },
+        "labels": [1, 10]
+      },
+      "9": {
+        "type": 1,
+        "title": "list",
+        "content": "item 1\nitem 2",
+        "metadata": "{\"type\":\"list\",\"checked\":[false,true]}",
+        "added": "2019-01-01T00:00:00.000Z",
+        "modified": "2019-02-01T00:00:00.000Z",
+        "status": 1,
+        "pinned": 0,
+        "labels": [1, 3]
+      }
+    },
+    "labels": {
+      "1": {"name": "label0", "hidden": true},
+      "3": {"name": "label1"},
+      "10": {"name": "label2"}
+    }
+  },
+  "version": 3
+}
+        """.trim().replace("\n", "")
+        assertEquals(ImportResult.BAD_FORMAT, jsonManager.importJsonData(jsonData2))
+
+        @Language("JSON") val jsonData3 = """{
+  "encryptedNotesData": {
+    "salt": "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI",
+    "nonce":"B+kFILwu8GLF1noQ",
+    "ciphertext":"DwSQ5XQfkqTjhJf58JbrDZAMLhGQfnYWS4zWcrXwkkvQDAlwmE77vyatw1xem/iKqCk2oq24c1+tlOSXEiczT1JY12W6YiLN9o9v3xkYYhIrNuPTSMgtG2n8BoEpvop6Wa1ZJNlq323WnoDvlBzOUovmyzomCqrlQ8+d6xgpfBi2YPDtg+QRpUg0mCz9CBBDQuDTMdWg0UD+AucChEKwXaG0VRAKPtRFgf/qALeC4r8oPwsS3UnLsLELZGWauG8QUl7lGUzR0Ayqruk7PaEG4tOHuN3jcPBwOZHKwDZUti/Ybzn4ClKuBN2gFpTqsSYM8vhpBDz+iJ7fwLiuLAX6yvJLwiex4TACi/ZvcNTjxk2mhSaqwObbY09CbGvYgPb20N+PGdOxSxoz1LnFT6lH0XqUEgjDcIR9av8yNWx41sWNBn9Q3i43zrRe19ygzGCAgU/defKtF7pA27f905UOKY2182qqxtUIBd82Bicgd2wt3j6t7/3o9neZTawGg03pyGQt+u1S6OEt3rcmpjwEr+9PG8alCkqHQEBjqPlpSCU0aBDCV0J01Ck6MTE+qAXYEYjHdCgVpvoQ96MNGEJl3ngkhweZcF+j+Y30LG4SnGHeym18m9yzuYtOm3D6nJ0AMiM/0cB1Qkaes8Naxl/Uesusc41000Y17qNBqhbMy16KEERw3xwnzdKlfE4rSo6L/o8XLolPpHvECmQR3VPZX835O+dAilHtThqYpBMU4AktJBf1ywvH2wNoiDWYGsuTpgZ5C97kJfvk0TF7bAPQtG/KiJxDy9G/OMGsHk3D9m8x5yhvdyw5r2+N5nD/DqY0bVsyqg7+FFzD+mPk60v29PuoBautxkqyoHhkQlEIM+Z6/D6eNO6hz50+SkplJVT8f0bURMmRPcKdVaaX/1yH5ztiO3WZsyIuRpx9cCTjgX51bGuvs1gveEjkw4f/squCem/XD0GBxFoOQjIfeVs5PXsgqiSCCSMjwF1sHY71dfBbTNAiR2PsK47LlrPMsrTJBkKqZptHZy+R+u1sZ9TL/I1kvqP0yoncAPUvzcTANzPyWY1zZL3Qrv5kB/5GtNwDJ33oblHfz/MU6vE/lR5sdo1y/tU5WVLz1OC3VL15h37w0dbgcsFvSZD/pGcyCW4OVYHpIXivnO+VXZmDzjBPnap35PAa5ggRjNkgGtaU8g9NGy4xjq9bLKPvKPK+U8moIbCOQYxENEsUJBjWf/X/r+aXLFoddEVOc/DYLoBTb24O95pi5SxLLCbEcKTmfnYL4iKCsMIMaNXMPM16DBOif4BhyUH1oZZz/E4swyhe3J8vxhUPqwI2njQ"
+  },
+  "version": 3
+}
+        """.trim().replace("\n", "")
+        assertEquals(ImportResult.BAD_FORMAT, jsonManager.importJsonData(jsonData3, importKey = key))
+    }
 }

--- a/app/src/androidTest/kotlin/com/maltaisn/notes/model/DefaultJsonManagerTest.kt
+++ b/app/src/androidTest/kotlin/com/maltaisn/notes/model/DefaultJsonManagerTest.kt
@@ -17,6 +17,8 @@
 package com.maltaisn.notes.model
 
 import android.content.Context
+import android.security.keystore.KeyProperties
+import android.security.keystore.KeyProtection
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -34,6 +36,7 @@ import com.maltaisn.notes.model.entity.Reminder
 import com.maltaisn.notesshared.dateFor
 import com.maltaisn.notesshared.testNote
 import com.maltaisn.recurpicker.Recurrence
+import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
@@ -42,6 +45,8 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.security.KeyStore
+import javax.crypto.spec.SecretKeySpec
 import kotlin.test.assertEquals
 
 @RunWith(AndroidJUnit4::class)
@@ -51,6 +56,7 @@ class DefaultJsonManagerTest {
     private lateinit var notesDao: NotesDao
     private lateinit var labelsDao: LabelsDao
 
+    private lateinit var prefsManager: PrefsManager
     private lateinit var jsonManager: JsonManager
 
     @Before
@@ -59,10 +65,14 @@ class DefaultJsonManagerTest {
         database = Room.inMemoryDatabaseBuilder(context, NotesDatabase::class.java).build()
         notesDao = database.notesDao()
         labelsDao = database.labelsDao()
+        prefsManager = mock {
+            on { encryptedImportKeyDerivationSalt } doReturn "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI"
+            on { encryptedExportKeyDerivationSalt } doReturn "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI"
+        }
         jsonManager = DefaultJsonManager(notesDao, labelsDao, Json {
             encodeDefaults = false
             ignoreUnknownKeys = true
-        }, mock())
+        }, mock(), prefsManager)
     }
 
     @After
@@ -70,8 +80,63 @@ class DefaultJsonManagerTest {
         database.close()
     }
 
+    private fun encryptionSetup(): SecretKeySpec {
+        // Set key in KeyStore
+        val keyMaterial = byteArrayOf(0x02,
+            0x02,
+            0x02,
+            0x02,
+            0x02,
+            0x02,
+            0x02,
+            0x02,
+            0x02,
+            0x02,
+            0x02,
+            0x02,
+            0x02,
+            0x02,
+            0x02,
+            0x02,
+            0x02,
+            0x02,
+            0x02,
+            0x02,
+            0x02,
+            0x02,
+            0x02,
+            0x02,
+            0x02,
+            0x02,
+            0x02,
+            0x02,
+            0x02,
+            0x02,
+            0x02,
+            0x02)
+        val key = SecretKeySpec(keyMaterial, KeyProperties.KEY_ALGORITHM_AES)
+        val keyStore = KeyStore.getInstance("AndroidKeyStore")
+        keyStore.load(null)
+        keyStore.setEntry(
+            "export_key",
+            KeyStore.SecretKeyEntry(key),
+            KeyProtection.Builder(KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT)
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                .build()
+        )
+        return key
+    }
+
     @Test
-    fun testJsonExport() = runBlocking {
+    fun testInvalidJsonImport() = runBlocking {
+        // wrong json structure
+        assertEquals(ImportResult.BAD_FORMAT, jsonManager.importJsonData("clearly not json"))
+    }
+
+    @Test
+    fun testUnencryptedJsonExport() = runBlocking {
+        prefsManager.shouldEncryptExportedData = false
         notesDao.insert(Note(id = 1,
             type = NoteType.TEXT,
             title = "note",
@@ -106,55 +171,57 @@ class DefaultJsonManagerTest {
 
         val jsonData = jsonManager.exportJsonData()
         assertEquals("""
-{"version":4,"notes":{"1":{"type":0,"title":"note","content":"content","metadata":"{\"type\":\"blank\"}",
-"added":"2020-01-01T05:00:00.000Z","modified":"2020-02-01T05:00:00.000Z","status":0,"pinned":2,
-"reminder":{"start":"2020-03-01T05:00:00.000Z","recurrence":"RRULE:FREQ=DAILY",
-"next":"2020-03-02T05:00:00.000Z","count":1,"done":false},"labels":[1,10]},"9":{"type":1,
+{"notesData":{"version":4,"notes":{"1":{"type":0,"title":"note","content":"content","metadata":"{\"type\":\"blank\"}",
+"added":"2020-01-01T00:00:00.000Z","modified":"2020-02-01T00:00:00.000Z","status":0,"pinned":2,
+"reminder":{"start":"2020-03-01T00:00:00.000Z","recurrence":"RRULE:FREQ=DAILY",
+"next":"2020-03-02T00:00:00.000Z","count":1,"done":false},"labels":[1,10]},"9":{"type":1,
 "title":"list","content":"item 1\nitem 2","metadata":"{\"type\":\"list\",\"checked\":[false,true]}",
-"added":"2019-01-01T05:00:00.000Z","modified":"2019-02-01T05:00:00.000Z","status":1,"pinned":0}},
-"labels":{"1":{"name":"label0"},"10":{"name":"label2","hidden":true}}}
+"added":"2019-01-01T00:00:00.000Z","modified":"2019-02-01T00:00:00.000Z","status":1,"pinned":0}},
+"labels":{"1":{"name":"label0"},"10":{"name":"label2","hidden":true}}}}
         """.trim().replace("\n", ""), jsonData)
     }
 
     @Test
-    fun testJsonImportClean() = runBlocking {
+    fun testUnencryptedJsonImportClean() = runBlocking {
         @Language("JSON") val jsonData = """{
-  "version": 3,
-  "notes": {
-    "1": {
-      "type": 0,
-      "title": "note",
-      "content": "content",
-      "metadata": "{\"type\":\"blank\"}",
-      "added": "2020-01-01T05:00:00.000Z",
-      "modified": "2020-02-01T05:00:00.000Z",
-      "status": 0,
-      "pinned": 2,
-      "reminder": {
-        "start": "2020-03-01T05:00:00.000Z",
-        "recurrence": "RRULE:FREQ=DAILY",
-        "next": "2020-03-02T05:00:00.000Z",
-        "count": 1,
-        "done": false
+  "notesData": {
+    "version": 3,
+    "notes": {
+      "1": {
+        "type": 0,
+        "title": "note",
+        "content": "content",
+        "metadata": "{\"type\":\"blank\"}",
+        "added": "2020-01-01T00:00:00.000Z",
+        "modified": "2020-02-01T00:00:00.000Z",
+        "status": 0,
+        "pinned": 2,
+        "reminder": {
+          "start": "2020-03-01T00:00:00.000Z",
+          "recurrence": "RRULE:FREQ=DAILY",
+          "next": "2020-03-02T00:00:00.000Z",
+          "count": 1,
+          "done": false
+        },
+        "labels": [1, 10]
       },
-      "labels": [1, 10]
+      "9": {
+        "type": 1,
+        "title": "list",
+        "content": "item 1\nitem 2",
+        "metadata": "{\"type\":\"list\",\"checked\":[false,true]}",
+        "added": "2019-01-01T00:00:00.000Z",
+        "modified": "2019-02-01T00:00:00.000Z",
+        "status": 1,
+        "pinned": 0,
+        "labels": [1, 3]
+      }
     },
-    "9": {
-      "type": 1,
-      "title": "list",
-      "content": "item 1\nitem 2",
-      "metadata": "{\"type\":\"list\",\"checked\":[false,true]}",
-      "added": "2019-01-01T05:00:00.000Z",
-      "modified": "2019-02-01T05:00:00.000Z",
-      "status": 1,
-      "pinned": 0,
-      "labels": [1, 3]
+    "labels": {
+      "1": {"name": "label0", "hidden": true},
+      "3": {"name": "label1"},
+      "10": {"name": "label2"}
     }
-  },
-  "labels": {
-    "1": {"name": "label0", "hidden": true},
-    "3": {"name": "label1"},
-    "10": {"name": "label2"}
   }
 }
         """.trim().replace("\n", "")
@@ -194,7 +261,570 @@ class DefaultJsonManagerTest {
     }
 
     @Test
-    fun testJsonImportMerge() = runBlocking {
+    fun testUnencryptedJsonImportMerge() = runBlocking {
+        // insert existing data
+        val label1 = Label(1, "label0")
+        val label3 = Label(3, "label3")
+        val label10 = Label(10, "label10")
+        notesDao.insertAll(listOf(
+            // merge case: same ID, no reminder on old, labels merge.
+            testNote(id = 1, added = dateFor("2020-01-01")),
+            // merge case: different dates, ID clash.
+            testNote(id = 9, added = dateFor("2021-01-01")),
+            // merge case: different reminders
+            testNote(id = 12, added = dateFor("2021-01-01"),
+                reminder = Reminder(dateFor("2021-01-02"), null, dateFor("2021-01-03"), 1, true)),
+        ))
+        labelsDao.insert(label1)
+        labelsDao.insert(label3)
+        labelsDao.insert(label10)
+        labelsDao.insertRefs(listOf(LabelRef(1, 1), LabelRef(1, 3)))
+
+        @Language("JSON") val jsonData = """{
+  "notesData": {
+    "version": 3,
+    "notes": {
+      "1": {
+        "type": 0,
+        "title": "note",
+        "content": "content",
+        "metadata": "{\"type\":\"blank\"}",
+        "added": "2020-01-01T00:00:00.000Z",
+        "modified": "2020-01-01T00:00:00.000Z",
+        "status": 0,
+        "pinned": 2,
+        "reminder": {
+          "start": "2020-03-01T00:00:00.000Z",
+          "recurrence": "RRULE:FREQ=DAILY",
+          "next": "2020-03-02T00:00:00.000Z",
+          "count": 1,
+          "done": false
+        },
+        "labels": [1, 3, 9]
+      },
+      "9": {
+        "type": 1,
+        "title": "list",
+        "content": "item 1\nitem 2",
+        "metadata": "{\"type\":\"list\",\"checked\":[false,true]}",
+        "added": "2019-01-01T00:00:00.000Z",
+        "modified": "2019-02-01T00:00:00.000Z",
+        "status": 1,
+        "pinned": 0,
+        "reminder": null,
+        "labels": [
+          1,
+          9
+        ]
+      },
+      "12": {
+        "type": 0,
+        "title": "note",
+        "content": "content",
+        "metadata": "{\"type\":\"blank\"}",
+        "added": "2021-01-01T00:00:00.000Z",
+        "modified": "2021-01-01T00:00:00.000Z",
+        "status": 0,
+        "pinned": 1,
+        "reminder": {
+          "start": "2021-01-02T00:00:00.000Z",
+          "next": "2022-01-02T00:00:00.000Z",
+          "count": 1,
+          "done": false
+        }
+      }
+    },
+    "labels": {
+      "1": {"name": "label0"},
+      "3": {"name": "label11"},
+      "9": {"name": "label10"}
+    }
+  }
+}
+        """.trim().replace("\n", "")
+        assertEquals(ImportResult.SUCCESS, jsonManager.importJsonData(jsonData))
+
+        val label9 = Label(9, "label10 (2)")
+        val label11 = Label(11, "label11")
+
+        assertEquals(setOf(label1, label3, label9, label10, label11), labelsDao.getAll().toSet())
+
+        assertEquals(setOf(
+            NoteWithLabels(Note(id = 1,
+                type = NoteType.TEXT,
+                title = "note",
+                content = "content",
+                metadata = BlankNoteMetadata,
+                addedDate = dateFor("2020-01-01"),
+                lastModifiedDate = dateFor("2020-01-01"),
+                status = NoteStatus.ACTIVE,
+                pinned = PinnedStatus.PINNED,
+                reminder = Reminder(dateFor("2020-03-01"), Recurrence(Recurrence.Period.DAILY),
+                    dateFor("2020-03-02"), 1, false)
+            ), listOf(label1, label3, label9, label11)),
+            NoteWithLabels(
+                testNote(id = 9, added = dateFor("2021-01-01")),
+                emptyList()
+            ),
+            NoteWithLabels(
+                testNote(id = 12, added = dateFor("2021-01-01"),
+                    reminder = Reminder(dateFor("2021-01-02"), null, dateFor("2021-01-03"), 1, true)),
+                emptyList()
+            ),
+            NoteWithLabels(Note(id = 13,
+                type = NoteType.LIST,
+                title = "list",
+                content = "item 1\nitem 2",
+                metadata = ListNoteMetadata(listOf(false, true)),
+                addedDate = dateFor("2019-01-01"),
+                lastModifiedDate = dateFor("2019-02-01"),
+                status = NoteStatus.ARCHIVED,
+                pinned = PinnedStatus.CANT_PIN,
+                reminder = null
+            ), listOf(label1, label9)),
+            NoteWithLabels(
+                testNote(id = 14, added = dateFor("2021-01-01"),
+                    reminder = Reminder(dateFor("2021-01-02"), null, dateFor("2022-01-02"), 1, false)),
+                emptyList()
+            ),
+        ), notesDao.getAll().toSet())
+    }
+
+    @Test
+    fun testUnencryptedJsonImportBadData() = runBlocking {
+        // invalid data (bad rrule)
+        assertEquals(ImportResult.BAD_FORMAT, jsonManager.importJsonData("""
+{"notesData":{"version":3,"notes":{"1":{"type":0,"title":"note","content":"content","metadata":"{\"type\":\"blank\"}",
+"added":"2020-01-01T05:00:00.000Z","modified":"2020-02-01T05:00:00.000Z","status":0,"pinned":2,
+"reminder":{"start":"2020-03-01T05:00:00.000Z","recurrence":"RRULE:FREQ=MILKY",
+"next":"2020-03-02T05:00:00.000Z","count":1,"done":false}}}}}
+        """.trim().replace("\n", "")))
+        // invalid data (missing field)
+        assertEquals(ImportResult.BAD_FORMAT, jsonManager.importJsonData("""
+{"notesData":{"version":3,"notes":{"1":{"type":0,"title":"note"}}}}
+        """.trim().replace("\n", "")))
+        // invalid version number
+        assertEquals(ImportResult.BAD_DATA, jsonManager.importJsonData("""{"notesData":{"version":0}}"""))
+    }
+
+    @Test
+    fun testUnencryptedJsonForwardCompatibility() = runBlocking {
+        // importing data with unsupported values for existing fields should fail
+        assertEquals(ImportResult.BAD_DATA, jsonManager.importJsonData("""
+{"notesData":{"version":11,"notes":{"1":{"type":100,"title":"note","content":"content","metadata":"{\"type\":\"drawing\"}",
+"added":"2020-01-01T00:00:00.000Z","modified":"2020-02-01T00:00:00.000Z","status":0,"pinned":2,
+"path":"M10,10h10v10h-10Z"}},"data":"data"}}
+        """.trim().replace("\n", "")))
+        assertEquals(ImportResult.FUTURE_VERSION, jsonManager.importJsonData("""
+{"notesData":{"version":10,"notes":{"1":{"type":0,"title":"note","content":"content","metadata":"{\"type\":\"blank\"}",
+"added":"2020-01-01T00:00:00.000Z","modified":"2020-02-01T00:00:00.000Z","status":0,"pinned":2,
+"path":"M10,10h10v10h-10Z"}},"data":"data"}}
+        """.trim().replace("\n", "")))
+    }
+
+    @Test
+    fun testEncryptedJsonExport() = runBlocking {
+        prefsManager.shouldEncryptExportedData = true
+        val key = encryptionSetup()
+        // Since the GCM nonce is chosen at random, comparing with a static test vector isn't easily possible.
+        // Instead, we import the exported data and check if it contains the expected values.
+        notesDao.insert(Note(id = 1,
+            type = NoteType.TEXT,
+            title = "note",
+            content = "content",
+            metadata = BlankNoteMetadata,
+            addedDate = dateFor("2020-01-01"),
+            lastModifiedDate = dateFor("2020-02-01"),
+            status = NoteStatus.ACTIVE,
+            pinned = PinnedStatus.PINNED,
+            reminder = Reminder(dateFor("2020-03-01"), Recurrence(Recurrence.Period.DAILY),
+                dateFor("2020-03-02"), 1, false)
+        ))
+        notesDao.insert(Note(id = 9,
+            type = NoteType.LIST,
+            title = "list",
+            content = "item 1\nitem 2",
+            metadata = ListNoteMetadata(listOf(false, true)),
+            addedDate = dateFor("2019-01-01"),
+            lastModifiedDate = dateFor("2019-02-01"),
+            status = NoteStatus.ARCHIVED,
+            pinned = PinnedStatus.CANT_PIN,
+            reminder = null
+        ))
+
+        labelsDao.insert(Label(1, "label0", false))
+        labelsDao.insert(Label(10, "label2", true))
+
+        labelsDao.insertRefs(listOf(
+            LabelRef(1, 1),
+            LabelRef(1, 10),
+        ))
+        val jsonData = jsonManager.exportJsonData()
+
+        notesDao.clear()
+        labelsDao.clear()
+
+        assertEquals(ImportResult.SUCCESS, jsonManager.importJsonData(jsonData, importKey = key))
+
+        val label1 = Label(1, "label0", false)
+        val label10 = Label(10, "label2", true)
+        assertEquals(setOf(label1, label10), labelsDao.getAll().toSet())
+
+        assertEquals(setOf(
+            NoteWithLabels(Note(id = 1,
+                type = NoteType.TEXT,
+                title = "note",
+                content = "content",
+                metadata = BlankNoteMetadata,
+                addedDate = dateFor("2020-01-01"),
+                lastModifiedDate = dateFor("2020-02-01"),
+                status = NoteStatus.ACTIVE,
+                pinned = PinnedStatus.PINNED,
+                reminder = Reminder(dateFor("2020-03-01"), Recurrence(Recurrence.Period.DAILY),
+                    dateFor("2020-03-02"), 1, false)
+            ), listOf(label1, label10)),
+            NoteWithLabels(Note(id = 9,
+                type = NoteType.LIST,
+                title = "list",
+                content = "item 1\nitem 2",
+                metadata = ListNoteMetadata(listOf(false, true)),
+                addedDate = dateFor("2019-01-01"),
+                lastModifiedDate = dateFor("2019-02-01"),
+                status = NoteStatus.ARCHIVED,
+                pinned = PinnedStatus.CANT_PIN,
+                reminder = null
+            ), listOf()),
+        ), notesDao.getAll().toSet())
+    }
+
+    @Test
+    fun testEncryptedJsonImportClean() = runBlocking {
+        val key = encryptionSetup()
+        // The test data is identical to the one used in testUnencryptedJsonImportClean
+        @Language("JSON") val jsonData = """{
+  "encryptedNotesData": {
+    "salt": "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI",
+    "nonce":"B+kFILwu8GLF1noQ",
+    "ciphertext":"DwSQ5XQfkqTjhJf58JbrDZAMLhGQfnYWS4zWcrXwkkvQDAlwmE77vyatw1xem/iKqCk2oq24c1+tlOSXEiczT1JY12W6YiLN9o9v3xkYYhIrNuPTSMgtG2n8BoEpvop6Wa1ZJNlq323WnoDvlBzOUovmyzomCqrlQ8+d6xgpfBi2YPDtg+QRpUg0mCz9CBBDQuDTMdWg0UD+AucChEKwXaG0VRAKPtRFgf/qALeC4r8oPwsS3UnLsLELZGWauG8QUl7lGUzR0Ayqruk7PaEG4tOHuN3jcPBwOZHKwDZUti/Ybzn4ClKuBN2gFpTqsSYM8vhpBDz+iJ7fwLiuLAX6yvJLwiex4TACi/ZvcNTjxk2mhSaqwObbY09CbGvYgPb20N+PGdOxSxoz1LnFT6lH0XqUEgjDcIR9av8yNWx41sWNBn9Q3i43zrRe19ygzGCAgU/defKtF7pA27f905UOKY2182qqxtUIBd82Bicgd2wt3j6t7/3o9neZTawGg03pyGQt+u1S6OEt3rcmpjwEr+9PG8alCkqHQEBjqPlpSCU0aBDCV0J01Ck6MTE+qAXYEYjHdCgVpvoQ96MNGEJl3ngkhweZcF+j+Y30LG4SnGHeym18m9yzuYtOm3D6nJ0AMiM/0cB1Qkaes8Naxl/Uesusc41000Y17qNBqhbMy16KEERw3xwnzdKlfE4rSo6L/o8XLolPpHvECmQR3VPZX835O+dAilHtThqYpBMU4AktJBf1ywvH2wNoiDWYGsuTpgZ5C97kJfvk0TF7bAPQtG/KiJxDy9G/OMGsHk3D9m8x5yhvdyw5r2+N5nD/DqY0bVsyqg7+FFzD+mPk60v29PuoBautxkqyoHhkQlEIM+Z6/D6eNO6hz50+SkplJVT8f0bURMmRPcKdVaaX/1yH5ztiO3WZsyIuRpx9cCTjgX51bGuvs1gveEjkw4f/squCem/XD0GBxFoOQjIfeVs5PXsgqiSCCSMjwF1sHY71dfBbTNAiR2PsK47LlrPMsrTJBkKqZptHZy+R+u1sZ9TL/I1kvqP0yoncAPUvzcTANzPyWY1zZL3Qrv5kB/5GtNwDJ33oblHfz/MU6vE/lR5sdo1y/tU5WVLz1OC3VL15h37w0dbgcsFvSZD/pGcyCW4OVYHpIXivnO+VXZmDzjBPnap35PAa5ggRjNkgGtaU8g9NGy4xjq9bLKPvKPK+U8moIbCOQYxENEsUJBjWf/X/r+aXLFoddEVOc/DYLoBTb24O95pi5SxLLCbEcKTmfnYL4iKCsMIMaNXMPM16DBOif4BhyUH1oZZz/E4swyhe3J8vxhUPqwI2njQ"
+  }
+}
+        """.trim().replace("\n", "")
+        assertEquals(ImportResult.SUCCESS, jsonManager.importJsonData(jsonData, importKey = key))
+
+        val label1 = Label(1, "label0", hidden = true)
+        val label3 = Label(3, "label1")
+        val label10 = Label(10, "label2")
+
+        assertEquals(setOf(label1, label3, label10), labelsDao.getAll().toSet())
+
+        assertEquals(setOf(
+            NoteWithLabels(Note(id = 1,
+                type = NoteType.TEXT,
+                title = "note",
+                content = "content",
+                metadata = BlankNoteMetadata,
+                addedDate = dateFor("2020-01-01"),
+                lastModifiedDate = dateFor("2020-02-01"),
+                status = NoteStatus.ACTIVE,
+                pinned = PinnedStatus.PINNED,
+                reminder = Reminder(dateFor("2020-03-01"), Recurrence(Recurrence.Period.DAILY),
+                    dateFor("2020-03-02"), 1, false)
+            ), listOf(label1, label10)),
+            NoteWithLabels(Note(id = 9,
+                type = NoteType.LIST,
+                title = "list",
+                content = "item 1\nitem 2",
+                metadata = ListNoteMetadata(listOf(false, true)),
+                addedDate = dateFor("2019-01-01"),
+                lastModifiedDate = dateFor("2019-02-01"),
+                status = NoteStatus.ARCHIVED,
+                pinned = PinnedStatus.CANT_PIN,
+                reminder = null
+            ), listOf(label1, label3)),
+        ), notesDao.getAll().toSet())
+    }
+
+    @Test
+    fun testEncryptedJsonImportMerge() = runBlocking {
+        val key = encryptionSetup()
+
+        // insert existing data
+        val label1 = Label(1, "label0")
+        val label3 = Label(3, "label3")
+        val label10 = Label(10, "label10")
+        notesDao.insertAll(listOf(
+            // merge case: same ID, no reminder on old, labels merge.
+            testNote(id = 1, added = dateFor("2020-01-01")),
+            // merge case: different dates, ID clash.
+            testNote(id = 9, added = dateFor("2021-01-01")),
+            // merge case: different reminders
+            testNote(id = 12, added = dateFor("2021-01-01"),
+                reminder = Reminder(dateFor("2021-01-02"), null, dateFor("2021-01-03"), 1, true)),
+        ))
+        labelsDao.insert(label1)
+        labelsDao.insert(label3)
+        labelsDao.insert(label10)
+        labelsDao.insertRefs(listOf(LabelRef(1, 1), LabelRef(1, 3)))
+
+        // The test data is identical to the one used in testUnencryptedJsonImportMerge
+        @Language("JSON") val jsonData = """{
+  "encryptedNotesData": {
+    "salt": "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI",
+    "nonce":"QyUp/nMOTWaJqrRv",
+    "ciphertext": "/hRHbo7THTXaKaus+yF+tskMDXxOTwVWJP3eZx0hrEZllK/tYEWkd0IUctAb3kiv6GW2SLRxX7T1Y7+OAaa7HbyJmass+0tVwmh61drLobeEylEQGwLSNfvm3TBz7Von9R8S8s5B5rg4IHXC8kqVSH9PAdg9LlUqrLTLtoN8bRk4SrnOsK+Kj1RLgUhJ9SYNeKpqJaUYHHBQpy88SviMAWSksNBrWMVdMXqvT7M2JT6+0scHwboHlHn74c66YiVGM6SuCJNlQWSCFG6znXXL7xBJ8Jhc/j5JbM934ubN0Y6tU5Hu04UP0E8l65WdQGqHwIMGMtyzkSFEJuaLy011+lwssPUmgfeDDPHmRRMgoQsruhx4kTOSZ97XuHHMb7ILpYUT6CtlR443nIbrXZnTNXna6B+KlmQpmHNenKlSo9pEh0LAndOqzgn8f1nqlVPqryNt5g8hBzmZCwL89tYcZyJeJKQ6cuJNRigcJISThlNIqYdzygmENWi/bBzY8uM3ofH1zdQnm4TOfFU9oSXNbumPZYojw6kkHOOk6UAYqXIpmtOSscB94vtOhB6QSdGDiUa+9DXsMajBNy/hhvob10yG1si+ejysBjMBTgP3UTaDwarCSzDI8fkjH9pwljtSgT54AkLGVRTn4ryeFF1c0cGpjHHKqIpm2AV3qvkRLbP/TkHGkLYAnpgZXQZ14fo/jFrZTgD+YfCji0PqLi0LYirILqLIXYY3tEF4/NCVeDK1IpyQe9lryt0Hr7FWZRwiprBNL1LdL948JrjhOlJP+KLtZ0q9HABseO7Oqd8l3lNmqe2PrLyJQHkbovVqE+SJU4w7BRU9OuZ6sMfKjMJpp0PmuKE1Hspq98qlKdsTg2Pc7o89ZRX/f9hz2MyY9RJT357SmxFePGeUiDIlvhVlx4aglY451lD+gs4ubFR21eH9uA8RszXEfd52UWxFE1sHKBRJkG/BwMvPqcYgG4FMYwT+IbaM+37k9sdF7w4kYMabMeSOBK4w8fW6iZRNAdqjEToVhxRF0id17w1vB/IyaS8xcf59BVhP6hsSnpF0jebc8GeggN2XqLYrTHTbEaPraMQ2UwWk2+WBYO7QZ/it12Bv9HZ/IWCUFdjpKMZGt7EVSseVu3Fij2QZ+fhE3gMxI8EOJx4uY9FIs1bWYAQxi6/dXNm+lDHLmU7atRzN2AHQZxFN2mCd9JedLlRWX29bzG5Z8lISFShqp1eHN3BwjK41r/4BbLqAWDOMuwqiD9N+TeQGldpWd2HFTp26DlcBduXPtkzUP3dn8r+OWz77ytFNydX0LIbAVyAc4qrtJURc/yUU9uXBAsR+jOtBjzCyAVR5oz+yNLWWbhGZPaQMd3T6q0TWQAR6jAbqT1pvM9ye1iy73atSx8pJOjjyENS90k8J2y0hQGEi46I3gaXASb+8JJdQ+zS0ToRF1gbfTKfu3M4FuHa06JNC0jhg+O6qDPIl6y9Zun4WMTos6oh1PaqG951A8jdKTQ60lUSY1ygDWn074Eg3GKya2Ui+8oj6SEoRkI9ELYU77eqBOOirH/idXrnknjqAnPHpWgYir2K5gpxbkP2tzQatwB0vo/Arwjvy+MlPdVgCTVIxu+NRpQBYD10TOp00ggIfHj9lwSU6oSX5JANqIqLQ6F2Lqm8/szf8KPAm4NSz/392vnFT5cyViJxozprer8rAZnUCuv9a//dlEzozRGDFfqg+BFXNdSB5XKSNgaEnD9nVMRqHUJ4QuVcN8iuYA0Fek6SSg9eOGDVA+6fXj+2xMrhMnX7I3o8Q2w3zT0nuZtDxjdl3HdxBigsgTnRfYNyKyvJiv1XLB8IqtJCa69DXf2tTEp0938XsCjGnnXcl/w9wtShM1uwB1EiCfmNRKi7pGNTj089a/O1LIxQYQ54kMgSd2iAcMiJTtJ6b0M99JHmZ960ZTBdt0tDI0LYm+b/TT7H3OA"
+  }
+}
+        """.trim().replace("\n", "")
+        assertEquals(ImportResult.SUCCESS, jsonManager.importJsonData(jsonData, importKey = key))
+
+        val label9 = Label(9, "label10 (2)")
+        val label11 = Label(11, "label11")
+
+        assertEquals(setOf(label1, label3, label9, label10, label11), labelsDao.getAll().toSet())
+
+        assertEquals(setOf(
+            NoteWithLabels(Note(id = 1,
+                type = NoteType.TEXT,
+                title = "note",
+                content = "content",
+                metadata = BlankNoteMetadata,
+                addedDate = dateFor("2020-01-01"),
+                lastModifiedDate = dateFor("2020-01-01"),
+                status = NoteStatus.ACTIVE,
+                pinned = PinnedStatus.PINNED,
+                reminder = Reminder(dateFor("2020-03-01"), Recurrence(Recurrence.Period.DAILY),
+                    dateFor("2020-03-02"), 1, false)
+            ), listOf(label1, label3, label9, label11)),
+            NoteWithLabels(
+                testNote(id = 9, added = dateFor("2021-01-01")),
+                emptyList()
+            ),
+            NoteWithLabels(
+                testNote(id = 12, added = dateFor("2021-01-01"),
+                    reminder = Reminder(dateFor("2021-01-02"), null, dateFor("2021-01-03"), 1, true)),
+                emptyList()
+            ),
+            NoteWithLabels(Note(id = 13,
+                type = NoteType.LIST,
+                title = "list",
+                content = "item 1\nitem 2",
+                metadata = ListNoteMetadata(listOf(false, true)),
+                addedDate = dateFor("2019-01-01"),
+                lastModifiedDate = dateFor("2019-02-01"),
+                status = NoteStatus.ARCHIVED,
+                pinned = PinnedStatus.CANT_PIN,
+                reminder = null
+            ), listOf(label1, label9)),
+            NoteWithLabels(
+                testNote(id = 14, added = dateFor("2021-01-01"),
+                    reminder = Reminder(dateFor("2021-01-02"), null, dateFor("2022-01-02"), 1, false)),
+                emptyList()
+            ),
+        ), notesDao.getAll().toSet())
+    }
+
+    @Test
+    fun testEncryptedJsonImportBadData() = runBlocking {
+        val key = encryptionSetup()
+        // invalid data (bad rrule)
+        @Language("JSON") val jsonDataBadRrule = """{
+  "encryptedNotesData": {
+    "salt": "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI",
+    "nonce":"zk18Yk2BLLfTxMps",
+    "ciphertext":"Up3FFXcXnKgpng1+nrxarmfSfEck5HxYDAGMg15LtYEtNPqCRMIFZAZ1juylZJ5YlPWoeL4wyUJl5Jypwu8IkmUljm8M1gsY16N5fyYq51OwH5LZ871+H/uXbFb58XpIEf1z075rXdTzCAzAtcrPymDNnXBGtNe42hgjStGn9qQWrRwm0IMyMjpcIfvrI3cxbuZkISiva5ec2i1/XeunW/NuKKxivHLiuTrS70WUsKm5+4zetajI9Mu+Pu2bjzkVYvU8eJD3zqqVluHpiY73a03UJFZQcf9lgZhCPCJG5pDVyLy9ieCVppTwSCRGYRmaOrf57Q+JEC24nbAKe6ULQmz1NWFuG37E6u5yTg1QZlxyK0D392oXRK9tbuW8BPYk2mLuD0sct3KKzWmIhJYaSXPPviaNRZZHROrsQayms1gJBW/NXekyreH0md5DGOD1+gdqv4WNF8hy4+HvAYyOB8EEUw"
+  }
+}
+        """.trim().replace("\n", "")
+        assertEquals(ImportResult.BAD_FORMAT, jsonManager.importJsonData(jsonDataBadRrule, importKey = key))
+        // invalid data (missing field)
+        @Language("JSON") val jsonDataMissingField = """{
+  "encryptedNotesData": {
+    "salt": "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI",
+    "nonce":"+2+q/POnSHNbar6L",
+    "ciphertext":"hd0nyl8JKmzQq0cMxHWVumGUTTlCPAGFWODfB4iCx1xlIfdYLbgLIV+4NOjVLObxK3pJYr7eYw67NwvPYecTPbOC92S3"
+  }
+}
+        """.trim().replace("\n", "")
+        assertEquals(ImportResult.BAD_FORMAT, jsonManager.importJsonData(jsonDataMissingField, importKey = key))
+        // invalid version number
+        @Language("JSON") val jsonDataInvalidVersion = """{
+  "encryptedNotesData": {
+    "salt": "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI",
+    "nonce":"QsdNJ32Nao1FmUp3",
+    "ciphertext":"sz4c0uiToCZ8RHSvBXI8AcVs2mFcD+oOjf5i7+Y"
+  }
+}
+        """.trim().replace("\n", "")
+        assertEquals(ImportResult.BAD_DATA, jsonManager.importJsonData(jsonDataInvalidVersion, importKey = key))
+    }
+
+    @Test
+    fun testEncryptedInvalidJsonImport() = runBlocking {
+        val key = encryptionSetup()
+        // wrong json structure
+        @Language("JSON") val jsonData = """{
+  "encryptedNotesData": {
+    "salt": "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI",
+    "nonce":"BdnxU+ElFPIGlKJJ",
+    "ciphertext":"j395X4746QzYPWEvE7nz2V0MNYzkIk+5HNrq9tsKrKI"
+  }
+}
+        """.trim().replace("\n", "")
+        assertEquals(ImportResult.BAD_FORMAT, jsonManager.importJsonData(jsonData, importKey = key))
+    }
+
+    @Test
+    fun testEncryptedJsonImportWithIncorrectKey() = runBlocking {
+        @Language("JSON") val jsonDataWithoutKey = """{
+  "encryptedNotesData": {
+    "salt": "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI",
+    "nonce":"B+kFILwu8GLF1noQ",
+    "ciphertext":"DwSQ5XQfkqTjhJf58JbrDZAMLhGQfnYWS4zWcrXwkkvQDAlwmE77vyatw1xem/iKqCk2oq24c1+tlOSXEiczT1JY12W6YiLN9o9v3xkYYhIrNuPTSMgtG2n8BoEpvop6Wa1ZJNlq323WnoDvlBzOUovmyzomCqrlQ8+d6xgpfBi2YPDtg+QRpUg0mCz9CBBDQuDTMdWg0UD+AucChEKwXaG0VRAKPtRFgf/qALeC4r8oPwsS3UnLsLELZGWauG8QUl7lGUzR0Ayqruk7PaEG4tOHuN3jcPBwOZHKwDZUti/Ybzn4ClKuBN2gFpTqsSYM8vhpBDz+iJ7fwLiuLAX6yvJLwiex4TACi/ZvcNTjxk2mhSaqwObbY09CbGvYgPb20N+PGdOxSxoz1LnFT6lH0XqUEgjDcIR9av8yNWx41sWNBn9Q3i43zrRe19ygzGCAgU/defKtF7pA27f905UOKY2182qqxtUIBd82Bicgd2wt3j6t7/3o9neZTawGg03pyGQt+u1S6OEt3rcmpjwEr+9PG8alCkqHQEBjqPlpSCU0aBDCV0J01Ck6MTE+qAXYEYjHdCgVpvoQ96MNGEJl3ngkhweZcF+j+Y30LG4SnGHeym18m9yzuYtOm3D6nJ0AMiM/0cB1Qkaes8Naxl/Uesusc41000Y17qNBqhbMy16KEERw3xwnzdKlfE4rSo6L/o8XLolPpHvECmQR3VPZX835O+dAilHtThqYpBMU4AktJBf1ywvH2wNoiDWYGsuTpgZ5C97kJfvk0TF7bAPQtG/KiJxDy9G/OMGsHk3D9m8x5yhvdyw5r2+N5nD/DqY0bVsyqg7+FFzD+mPk60v29PuoBautxkqyoHhkQlEIM+Z6/D6eNO6hz50+SkplJVT8f0bURMmRPcKdVaaX/1yH5ztiO3WZsyIuRpx9cCTjgX51bGuvs1gveEjkw4f/squCem/XD0GBxFoOQjIfeVs5PXsgqiSCCSMjwF1sHY71dfBbTNAiR2PsK47LlrPMsrTJBkKqZptHZy+R+u1sZ9TL/I1kvqP0yoncAPUvzcTANzPyWY1zZL3Qrv5kB/5GtNwDJ33oblHfz/MU6vE/lR5sdo1y/tU5WVLz1OC3VL15h37w0dbgcsFvSZD/pGcyCW4OVYHpIXivnO+VXZmDzjBPnap35PAa5ggRjNkgGtaU8g9NGy4xjq9bLKPvKPK+U8moIbCOQYxENEsUJBjWf/X/r+aXLFoddEVOc/DYLoBTb24O95pi5SxLLCbEcKTmfnYL4iKCsMIMaNXMPM16DBOif4BhyUH1oZZz/E4swyhe3J8vxhUPqwI2njQ"
+  }
+}
+        """.trim().replace("\n", "")
+        assertEquals(ImportResult.KEY_MISSING_OR_INCORRECT, jsonManager.importJsonData(jsonDataWithoutKey))
+
+        val key = SecretKeySpec(ByteArray(32), KeyProperties.KEY_ALGORITHM_AES)
+        @Language("JSON") val jsonDataIncorrectKey = """{
+  "encryptedNotesData": {
+    "salt": "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI",
+    "nonce":"B+kFILwu8GLF1noQ",
+    "ciphertext":"DwSQ5XQfkqTjhJf58JbrDZAMLhGQfnYWS4zWcrXwkkvQDAlwmE77vyatw1xem/iKqCk2oq24c1+tlOSXEiczT1JY12W6YiLN9o9v3xkYYhIrNuPTSMgtG2n8BoEpvop6Wa1ZJNlq323WnoDvlBzOUovmyzomCqrlQ8+d6xgpfBi2YPDtg+QRpUg0mCz9CBBDQuDTMdWg0UD+AucChEKwXaG0VRAKPtRFgf/qALeC4r8oPwsS3UnLsLELZGWauG8QUl7lGUzR0Ayqruk7PaEG4tOHuN3jcPBwOZHKwDZUti/Ybzn4ClKuBN2gFpTqsSYM8vhpBDz+iJ7fwLiuLAX6yvJLwiex4TACi/ZvcNTjxk2mhSaqwObbY09CbGvYgPb20N+PGdOxSxoz1LnFT6lH0XqUEgjDcIR9av8yNWx41sWNBn9Q3i43zrRe19ygzGCAgU/defKtF7pA27f905UOKY2182qqxtUIBd82Bicgd2wt3j6t7/3o9neZTawGg03pyGQt+u1S6OEt3rcmpjwEr+9PG8alCkqHQEBjqPlpSCU0aBDCV0J01Ck6MTE+qAXYEYjHdCgVpvoQ96MNGEJl3ngkhweZcF+j+Y30LG4SnGHeym18m9yzuYtOm3D6nJ0AMiM/0cB1Qkaes8Naxl/Uesusc41000Y17qNBqhbMy16KEERw3xwnzdKlfE4rSo6L/o8XLolPpHvECmQR3VPZX835O+dAilHtThqYpBMU4AktJBf1ywvH2wNoiDWYGsuTpgZ5C97kJfvk0TF7bAPQtG/KiJxDy9G/OMGsHk3D9m8x5yhvdyw5r2+N5nD/DqY0bVsyqg7+FFzD+mPk60v29PuoBautxkqyoHhkQlEIM+Z6/D6eNO6hz50+SkplJVT8f0bURMmRPcKdVaaX/1yH5ztiO3WZsyIuRpx9cCTjgX51bGuvs1gveEjkw4f/squCem/XD0GBxFoOQjIfeVs5PXsgqiSCCSMjwF1sHY71dfBbTNAiR2PsK47LlrPMsrTJBkKqZptHZy+R+u1sZ9TL/I1kvqP0yoncAPUvzcTANzPyWY1zZL3Qrv5kB/5GtNwDJ33oblHfz/MU6vE/lR5sdo1y/tU5WVLz1OC3VL15h37w0dbgcsFvSZD/pGcyCW4OVYHpIXivnO+VXZmDzjBPnap35PAa5ggRjNkgGtaU8g9NGy4xjq9bLKPvKPK+U8moIbCOQYxENEsUJBjWf/X/r+aXLFoddEVOc/DYLoBTb24O95pi5SxLLCbEcKTmfnYL4iKCsMIMaNXMPM16DBOif4BhyUH1oZZz/E4swyhe3J8vxhUPqwI2njQ"
+  }
+}
+        """.trim().replace("\n", "")
+        assertEquals(ImportResult.KEY_MISSING_OR_INCORRECT,
+            jsonManager.importJsonData(jsonDataIncorrectKey, importKey = key))
+    }
+
+    @Test
+    fun testEncryptedJsonImportWithIncorrectNonce() = runBlocking {
+        val key = encryptionSetup()
+        @Language("JSON") val jsonDataWithoutNonce = """{
+  "encryptedNotesData": {
+    "salt": "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI",
+    "ciphertext":"DwSQ5XQfkqTjhJf58JbrDZAMLhGQfnYWS4zWcrXwkkvQDAlwmE77vyatw1xem/iKqCk2oq24c1+tlOSXEiczT1JY12W6YiLN9o9v3xkYYhIrNuPTSMgtG2n8BoEpvop6Wa1ZJNlq323WnoDvlBzOUovmyzomCqrlQ8+d6xgpfBi2YPDtg+QRpUg0mCz9CBBDQuDTMdWg0UD+AucChEKwXaG0VRAKPtRFgf/qALeC4r8oPwsS3UnLsLELZGWauG8QUl7lGUzR0Ayqruk7PaEG4tOHuN3jcPBwOZHKwDZUti/Ybzn4ClKuBN2gFpTqsSYM8vhpBDz+iJ7fwLiuLAX6yvJLwiex4TACi/ZvcNTjxk2mhSaqwObbY09CbGvYgPb20N+PGdOxSxoz1LnFT6lH0XqUEgjDcIR9av8yNWx41sWNBn9Q3i43zrRe19ygzGCAgU/defKtF7pA27f905UOKY2182qqxtUIBd82Bicgd2wt3j6t7/3o9neZTawGg03pyGQt+u1S6OEt3rcmpjwEr+9PG8alCkqHQEBjqPlpSCU0aBDCV0J01Ck6MTE+qAXYEYjHdCgVpvoQ96MNGEJl3ngkhweZcF+j+Y30LG4SnGHeym18m9yzuYtOm3D6nJ0AMiM/0cB1Qkaes8Naxl/Uesusc41000Y17qNBqhbMy16KEERw3xwnzdKlfE4rSo6L/o8XLolPpHvECmQR3VPZX835O+dAilHtThqYpBMU4AktJBf1ywvH2wNoiDWYGsuTpgZ5C97kJfvk0TF7bAPQtG/KiJxDy9G/OMGsHk3D9m8x5yhvdyw5r2+N5nD/DqY0bVsyqg7+FFzD+mPk60v29PuoBautxkqyoHhkQlEIM+Z6/D6eNO6hz50+SkplJVT8f0bURMmRPcKdVaaX/1yH5ztiO3WZsyIuRpx9cCTjgX51bGuvs1gveEjkw4f/squCem/XD0GBxFoOQjIfeVs5PXsgqiSCCSMjwF1sHY71dfBbTNAiR2PsK47LlrPMsrTJBkKqZptHZy+R+u1sZ9TL/I1kvqP0yoncAPUvzcTANzPyWY1zZL3Qrv5kB/5GtNwDJ33oblHfz/MU6vE/lR5sdo1y/tU5WVLz1OC3VL15h37w0dbgcsFvSZD/pGcyCW4OVYHpIXivnO+VXZmDzjBPnap35PAa5ggRjNkgGtaU8g9NGy4xjq9bLKPvKPK+U8moIbCOQYxENEsUJBjWf/X/r+aXLFoddEVOc/DYLoBTb24O95pi5SxLLCbEcKTmfnYL4iKCsMIMaNXMPM16DBOif4BhyUH1oZZz/E4swyhe3J8vxhUPqwI2njQ"
+  }
+}
+        """.trim().replace("\n", "")
+        assertEquals(ImportResult.BAD_FORMAT, jsonManager.importJsonData(jsonDataWithoutNonce, importKey = key))
+
+        @Language("JSON") val jsonDataIncorrectNonce = """{
+  "encryptedNotesData": {
+    "salt": "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI",
+    "nonce":"AAAAAAAAAAAAAAAA",
+    "ciphertext":"DwSQ5XQfkqTjhJf58JbrDZAMLhGQfnYWS4zWcrXwkkvQDAlwmE77vyatw1xem/iKqCk2oq24c1+tlOSXEiczT1JY12W6YiLN9o9v3xkYYhIrNuPTSMgtG2n8BoEpvop6Wa1ZJNlq323WnoDvlBzOUovmyzomCqrlQ8+d6xgpfBi2YPDtg+QRpUg0mCz9CBBDQuDTMdWg0UD+AucChEKwXaG0VRAKPtRFgf/qALeC4r8oPwsS3UnLsLELZGWauG8QUl7lGUzR0Ayqruk7PaEG4tOHuN3jcPBwOZHKwDZUti/Ybzn4ClKuBN2gFpTqsSYM8vhpBDz+iJ7fwLiuLAX6yvJLwiex4TACi/ZvcNTjxk2mhSaqwObbY09CbGvYgPb20N+PGdOxSxoz1LnFT6lH0XqUEgjDcIR9av8yNWx41sWNBn9Q3i43zrRe19ygzGCAgU/defKtF7pA27f905UOKY2182qqxtUIBd82Bicgd2wt3j6t7/3o9neZTawGg03pyGQt+u1S6OEt3rcmpjwEr+9PG8alCkqHQEBjqPlpSCU0aBDCV0J01Ck6MTE+qAXYEYjHdCgVpvoQ96MNGEJl3ngkhweZcF+j+Y30LG4SnGHeym18m9yzuYtOm3D6nJ0AMiM/0cB1Qkaes8Naxl/Uesusc41000Y17qNBqhbMy16KEERw3xwnzdKlfE4rSo6L/o8XLolPpHvECmQR3VPZX835O+dAilHtThqYpBMU4AktJBf1ywvH2wNoiDWYGsuTpgZ5C97kJfvk0TF7bAPQtG/KiJxDy9G/OMGsHk3D9m8x5yhvdyw5r2+N5nD/DqY0bVsyqg7+FFzD+mPk60v29PuoBautxkqyoHhkQlEIM+Z6/D6eNO6hz50+SkplJVT8f0bURMmRPcKdVaaX/1yH5ztiO3WZsyIuRpx9cCTjgX51bGuvs1gveEjkw4f/squCem/XD0GBxFoOQjIfeVs5PXsgqiSCCSMjwF1sHY71dfBbTNAiR2PsK47LlrPMsrTJBkKqZptHZy+R+u1sZ9TL/I1kvqP0yoncAPUvzcTANzPyWY1zZL3Qrv5kB/5GtNwDJ33oblHfz/MU6vE/lR5sdo1y/tU5WVLz1OC3VL15h37w0dbgcsFvSZD/pGcyCW4OVYHpIXivnO+VXZmDzjBPnap35PAa5ggRjNkgGtaU8g9NGy4xjq9bLKPvKPK+U8moIbCOQYxENEsUJBjWf/X/r+aXLFoddEVOc/DYLoBTb24O95pi5SxLLCbEcKTmfnYL4iKCsMIMaNXMPM16DBOif4BhyUH1oZZz/E4swyhe3J8vxhUPqwI2njQ"
+  }
+}
+        """.trim().replace("\n", "")
+        assertEquals(ImportResult.KEY_MISSING_OR_INCORRECT,
+            jsonManager.importJsonData(jsonDataIncorrectNonce, importKey = key))
+    }
+
+    @Test
+    fun testEncryptedJsonForwardCompatibility() = runBlocking {
+        val key = encryptionSetup()
+        // importing data with unsupported values for existing fields should fail
+        @Language("JSON") val jsonData1 = """{
+  "encryptedNotesData": {
+    "salt": "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI",
+    "nonce":"dbIIGz5sG3qZO8/R",
+    "ciphertext":"4xCyvX+WHiji0+hiGP59ykDMwVgNfYGgPRRkvg2OtFfCLhOka19A+5n5SpMNS9HSoDzbzQXORp4ijQY+R9krxkV94QvU1PcpB07mDZcslsBzLhuLTR7a0AvIO+xpCodMuq8cHDmWfGTyGZmPLlTEjAZ60tSwuHPRAPA4dM9GlwfDeL2PdXaxIsckdtipAlA8RK6jner+vbS8B3DkSY/g3v/Uo1IcHIl9cVCoCz7DKHJZfRTjlXeqVuu0ZwuD8W7ihOjzzbDABWgnTZOgk6p+1Jn5cG/O71TPNivq6cdNupugoOdyImrzUp3+HpLHxe+/Rb1puRJ1BBc7s/4nSPVM85c7nam52qyA"
+  }
+}
+        """.trim().replace("\n", "")
+        assertEquals(ImportResult.BAD_DATA, jsonManager.importJsonData(jsonData1, importKey = key))
+        @Language("JSON") val jsonData2 = """{
+  "encryptedNotesData": {
+    "salt": "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI",
+    "nonce":"Qm8INVqCd49zvCJG",
+    "ciphertext":"PpUonn9kBwWS3WjAgtJdUlDy2All1N7lfRMYYw8MSDDUPYZAVzeu7rOH38j2Qz5IqWlWbam4RBKP+NihH12BHkI4iPKjSHjtb+XKSNJ0niSet+5SQBmqMhU74O0/YqkuR0aBHU7Rs6TRJYR9CthXtjTvnbCWAw2wOmriOvKRw9pN3VARXf7usw1UKf1/7BNoXU5zBLhjwLZMNvCCWbBotmGM06i/Gy6mg85kBXbLIhp6BAABwiM1uCow7ivgnid50ei1M5Z+13G92QV9jcsmlXAFO/OKrCc4MsIMGAp6G/e0+6jeuEE7W6i7DWsJmlYZomSd05K6t6Pzer3ViC6u3RHE7/Q"
+  }
+}
+        """.trim().replace("\n", "")
+        assertEquals(ImportResult.FUTURE_VERSION, jsonManager.importJsonData(jsonData2, importKey = key))
+    }
+
+    @Test
+    fun testLegacyJsonImportClean() = runBlocking {
+        @Language("JSON") val jsonData = """{
+  "version": 3,
+  "notes": {
+    "1": {
+      "type": 0,
+      "title": "note",
+      "content": "content",
+      "metadata": "{\"type\":\"blank\"}",
+      "added": "2020-01-01T00:00:00.000Z",
+      "modified": "2020-02-01T00:00:00.000Z",
+      "status": 0,
+      "pinned": 2,
+      "reminder": {
+        "start": "2020-03-01T00:00:00.000Z",
+        "recurrence": "RRULE:FREQ=DAILY",
+        "next": "2020-03-02T00:00:00.000Z",
+        "count": 1,
+        "done": false
+      },
+      "labels": [1, 10]
+    },
+    "9": {
+      "type": 1,
+      "title": "list",
+      "content": "item 1\nitem 2",
+      "metadata": "{\"type\":\"list\",\"checked\":[false,true]}",
+      "added": "2019-01-01T00:00:00.000Z",
+      "modified": "2019-02-01T00:00:00.000Z",
+      "status": 1,
+      "pinned": 0,
+      "labels": [1, 3]
+    }
+  },
+  "labels": {
+    "1": {"name": "label0"},
+    "3": {"name": "label1"},
+    "10": {"name": "label2"}
+  }
+}
+        """.trim().replace("\n", "")
+        assertEquals(ImportResult.SUCCESS, jsonManager.importJsonData(jsonData))
+
+        val label1 = Label(1, "label0")
+        val label3 = Label(3, "label1")
+        val label10 = Label(10, "label2")
+
+        assertEquals(setOf(label1, label3, label10), labelsDao.getAll().toSet())
+
+        assertEquals(setOf(
+            NoteWithLabels(Note(id = 1,
+                type = NoteType.TEXT,
+                title = "note",
+                content = "content",
+                metadata = BlankNoteMetadata,
+                addedDate = dateFor("2020-01-01"),
+                lastModifiedDate = dateFor("2020-02-01"),
+                status = NoteStatus.ACTIVE,
+                pinned = PinnedStatus.PINNED,
+                reminder = Reminder(dateFor("2020-03-01"), Recurrence(Recurrence.Period.DAILY),
+                    dateFor("2020-03-02"), 1, false)
+            ), listOf(label1, label10)),
+            NoteWithLabels(Note(id = 9,
+                type = NoteType.LIST,
+                title = "list",
+                content = "item 1\nitem 2",
+                metadata = ListNoteMetadata(listOf(false, true)),
+                addedDate = dateFor("2019-01-01"),
+                lastModifiedDate = dateFor("2019-02-01"),
+                status = NoteStatus.ARCHIVED,
+                pinned = PinnedStatus.CANT_PIN,
+                reminder = null
+            ), listOf(label1, label3)),
+        ), notesDao.getAll().toSet())
+    }
+
+    @Test
+    fun testLegacyJsonImportMerge() = runBlocking {
         // insert existing data
         val label1 = Label(1, "label0")
         val label3 = Label(3, "label3")
@@ -221,14 +851,14 @@ class DefaultJsonManagerTest {
       "title": "note",
       "content": "content",
       "metadata": "{\"type\":\"blank\"}",
-      "added": "2020-01-01T05:00:00.000Z",
-      "modified": "2020-01-01T05:00:00.000Z",
+      "added": "2020-01-01T00:00:00.000Z",
+      "modified": "2020-01-01T00:00:00.000Z",
       "status": 0,
       "pinned": 2,
       "reminder": {
-        "start": "2020-03-01T05:00:00.000Z",
+        "start": "2020-03-01T00:00:00.000Z",
         "recurrence": "RRULE:FREQ=DAILY",
-        "next": "2020-03-02T05:00:00.000Z",
+        "next": "2020-03-02T00:00:00.000Z",
         "count": 1,
         "done": false
       },
@@ -239,8 +869,8 @@ class DefaultJsonManagerTest {
       "title": "list",
       "content": "item 1\nitem 2",
       "metadata": "{\"type\":\"list\",\"checked\":[false,true]}",
-      "added": "2019-01-01T05:00:00.000Z",
-      "modified": "2019-02-01T05:00:00.000Z",
+      "added": "2019-01-01T00:00:00.000Z",
+      "modified": "2019-02-01T00:00:00.000Z",
       "status": 1,
       "pinned": 0,
       "reminder": null,
@@ -254,13 +884,13 @@ class DefaultJsonManagerTest {
       "title": "note",
       "content": "content",
       "metadata": "{\"type\":\"blank\"}",
-      "added": "2021-01-01T05:00:00.000Z",
-      "modified": "2021-01-01T05:00:00.000Z",
+      "added": "2021-01-01T00:00:00.000Z",
+      "modified": "2021-01-01T00:00:00.000Z",
       "status": 0,
       "pinned": 1,
       "reminder": {
-        "start": "2021-01-02T05:00:00.000Z",
-        "next": "2022-01-02T05:00:00.000Z",
+        "start": "2021-01-02T00:00:00.000Z",
+        "next": "2022-01-02T00:00:00.000Z",
         "count": 1,
         "done": false
       }
@@ -322,15 +952,13 @@ class DefaultJsonManagerTest {
     }
 
     @Test
-    fun testJsonImportBadData() = runBlocking {
-        // wrong json structure
-        assertEquals(ImportResult.BAD_FORMAT, jsonManager.importJsonData("clearly not json"))
+    fun testLegacyJsonImportBadData() = runBlocking {
         // invalid data (bad rrule)
         assertEquals(ImportResult.BAD_FORMAT, jsonManager.importJsonData("""
 {"version":3,"notes":{"1":{"type":0,"title":"note","content":"content","metadata":"{\"type\":\"blank\"}",
-"added":"2020-01-01T05:00:00.000Z","modified":"2020-02-01T05:00:00.000Z","status":0,"pinned":2,
-"reminder":{"start":"2020-03-01T05:00:00.000Z","recurrence":"RRULE:FREQ=MILKY",
-"next":"2020-03-02T05:00:00.000Z","count":1,"done":false}}}}
+"added":"2020-01-01T00:00:00.000Z","modified":"2020-02-01T00:00:00.000Z","status":0,"pinned":2,
+"reminder":{"start":"2020-03-01T00:00:00.000Z","recurrence":"RRULE:FREQ=MILKY",
+"next":"2020-03-02T00:00:00.000Z","count":1,"done":false}}}}
         """.trim().replace("\n", "")))
         // invalid data (missing field)
         assertEquals(ImportResult.BAD_FORMAT, jsonManager.importJsonData("""
@@ -341,16 +969,16 @@ class DefaultJsonManagerTest {
     }
 
     @Test
-    fun testJsonForwardCompatibility() = runBlocking {
+    fun testLegacyJsonForwardCompatibility() = runBlocking {
         // importing data with unsupported values for existing fields should fail
         assertEquals(ImportResult.BAD_DATA, jsonManager.importJsonData("""
 {"version":11,"notes":{"1":{"type":100,"title":"note","content":"content","metadata":"{\"type\":\"drawing\"}",
-"added":"2020-01-01T05:00:00.000Z","modified":"2020-02-01T05:00:00.000Z","status":0,"pinned":2,
+"added":"2020-01-01T00:00:00.000Z","modified":"2020-02-01T00:00:00.000Z","status":0,"pinned":2,
 "path":"M10,10h10v10h-10Z"}},"data":"data"}
         """.trim().replace("\n", "")))
         assertEquals(ImportResult.FUTURE_VERSION, jsonManager.importJsonData("""
 {"version":10,"notes":{"1":{"type":0,"title":"note","content":"content","metadata":"{\"type\":\"blank\"}",
-"added":"2020-01-01T05:00:00.000Z","modified":"2020-02-01T05:00:00.000Z","status":0,"pinned":2,
+"added":"2020-01-01T00:00:00.000Z","modified":"2020-02-01T00:00:00.000Z","status":0,"pinned":2,
 "path":"M10,10h10v10h-10Z"}},"data":"data"}
         """.trim().replace("\n", "")))
     }

--- a/app/src/androidTest/kotlin/com/maltaisn/notes/model/DefaultJsonManagerTest.kt
+++ b/app/src/androidTest/kotlin/com/maltaisn/notes/model/DefaultJsonManagerTest.kt
@@ -17,12 +17,13 @@
 package com.maltaisn.notes.model
 
 import android.content.Context
+import android.os.Build
 import android.security.keystore.KeyProperties
 import android.security.keystore.KeyProtection
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.maltaisn.notes.model.DefaultJsonManager.ImportResult
+import com.maltaisn.notes.model.JsonManager.ImportResult
 import com.maltaisn.notes.model.entity.BlankNoteMetadata
 import com.maltaisn.notes.model.entity.Label
 import com.maltaisn.notes.model.entity.LabelRef
@@ -59,6 +60,8 @@ class DefaultJsonManagerTest {
     private lateinit var prefsManager: PrefsManager
     private lateinit var jsonManager: JsonManager
 
+    private fun shouldIgnoreEncryptionTest() = Build.VERSION.SDK_INT < 26
+
     @Before
     fun createDatabase() {
         val context = ApplicationProvider.getApplicationContext<Context>()
@@ -82,39 +85,7 @@ class DefaultJsonManagerTest {
 
     private fun encryptionSetup(): SecretKeySpec {
         // Set key in KeyStore
-        val keyMaterial = byteArrayOf(0x02,
-            0x02,
-            0x02,
-            0x02,
-            0x02,
-            0x02,
-            0x02,
-            0x02,
-            0x02,
-            0x02,
-            0x02,
-            0x02,
-            0x02,
-            0x02,
-            0x02,
-            0x02,
-            0x02,
-            0x02,
-            0x02,
-            0x02,
-            0x02,
-            0x02,
-            0x02,
-            0x02,
-            0x02,
-            0x02,
-            0x02,
-            0x02,
-            0x02,
-            0x02,
-            0x02,
-            0x02)
-        val key = SecretKeySpec(keyMaterial, KeyProperties.KEY_ALGORITHM_AES)
+        val key = SecretKeySpec(ByteArray(32) { 0x02 }, KeyProperties.KEY_ALGORITHM_AES)
         val keyStore = KeyStore.getInstance("AndroidKeyStore")
         keyStore.load(null)
         keyStore.setEntry(
@@ -171,20 +142,19 @@ class DefaultJsonManagerTest {
 
         val jsonData = jsonManager.exportJsonData()
         assertEquals("""
-{"notesData":{"version":4,"notes":{"1":{"type":0,"title":"note","content":"content","metadata":"{\"type\":\"blank\"}",
+{"version":4,"notes":{"1":{"type":0,"title":"note","content":"content","metadata":"{\"type\":\"blank\"}",
 "added":"2020-01-01T00:00:00.000Z","modified":"2020-02-01T00:00:00.000Z","status":0,"pinned":2,
 "reminder":{"start":"2020-03-01T00:00:00.000Z","recurrence":"RRULE:FREQ=DAILY",
 "next":"2020-03-02T00:00:00.000Z","count":1,"done":false},"labels":[1,10]},"9":{"type":1,
 "title":"list","content":"item 1\nitem 2","metadata":"{\"type\":\"list\",\"checked\":[false,true]}",
 "added":"2019-01-01T00:00:00.000Z","modified":"2019-02-01T00:00:00.000Z","status":1,"pinned":0}},
-"labels":{"1":{"name":"label0"},"10":{"name":"label2","hidden":true}}}}
+"labels":{"1":{"name":"label0"},"10":{"name":"label2","hidden":true}}}
         """.trim().replace("\n", ""), jsonData)
     }
 
     @Test
     fun testUnencryptedJsonImportClean() = runBlocking {
         @Language("JSON") val jsonData = """{
-  "notesData": {
     "version": 3,
     "notes": {
       "1": {
@@ -223,7 +193,6 @@ class DefaultJsonManagerTest {
       "10": {"name": "label2"}
     }
   }
-}
         """.trim().replace("\n", "")
         assertEquals(ImportResult.SUCCESS, jsonManager.importJsonData(jsonData))
 
@@ -281,7 +250,6 @@ class DefaultJsonManagerTest {
         labelsDao.insertRefs(listOf(LabelRef(1, 1), LabelRef(1, 3)))
 
         @Language("JSON") val jsonData = """{
-  "notesData": {
     "version": 3,
     "notes": {
       "1": {
@@ -340,7 +308,6 @@ class DefaultJsonManagerTest {
       "9": {"name": "label10"}
     }
   }
-}
         """.trim().replace("\n", "")
         assertEquals(ImportResult.SUCCESS, jsonManager.importJsonData(jsonData))
 
@@ -394,36 +361,40 @@ class DefaultJsonManagerTest {
     fun testUnencryptedJsonImportBadData() = runBlocking {
         // invalid data (bad rrule)
         assertEquals(ImportResult.BAD_FORMAT, jsonManager.importJsonData("""
-{"notesData":{"version":3,"notes":{"1":{"type":0,"title":"note","content":"content","metadata":"{\"type\":\"blank\"}",
+{"version":3,"notes":{"1":{"type":0,"title":"note","content":"content","metadata":"{\"type\":\"blank\"}",
 "added":"2020-01-01T05:00:00.000Z","modified":"2020-02-01T05:00:00.000Z","status":0,"pinned":2,
 "reminder":{"start":"2020-03-01T05:00:00.000Z","recurrence":"RRULE:FREQ=MILKY",
-"next":"2020-03-02T05:00:00.000Z","count":1,"done":false}}}}}
+"next":"2020-03-02T05:00:00.000Z","count":1,"done":false}}}}
         """.trim().replace("\n", "")))
         // invalid data (missing field)
         assertEquals(ImportResult.BAD_FORMAT, jsonManager.importJsonData("""
-{"notesData":{"version":3,"notes":{"1":{"type":0,"title":"note"}}}}
+{"version":3,"notes":{"1":{"type":0,"title":"note"}}}
         """.trim().replace("\n", "")))
         // invalid version number
-        assertEquals(ImportResult.BAD_DATA, jsonManager.importJsonData("""{"notesData":{"version":0}}"""))
+        assertEquals(ImportResult.BAD_DATA, jsonManager.importJsonData("""{"version":0}"""))
     }
 
     @Test
     fun testUnencryptedJsonForwardCompatibility() = runBlocking {
         // importing data with unsupported values for existing fields should fail
         assertEquals(ImportResult.BAD_DATA, jsonManager.importJsonData("""
-{"notesData":{"version":11,"notes":{"1":{"type":100,"title":"note","content":"content","metadata":"{\"type\":\"drawing\"}",
+{"version":11,"notes":{"1":{"type":100,"title":"note","content":"content","metadata":"{\"type\":\"drawing\"}",
 "added":"2020-01-01T00:00:00.000Z","modified":"2020-02-01T00:00:00.000Z","status":0,"pinned":2,
-"path":"M10,10h10v10h-10Z"}},"data":"data"}}
+"path":"M10,10h10v10h-10Z"}},"data":"data"}
         """.trim().replace("\n", "")))
         assertEquals(ImportResult.FUTURE_VERSION, jsonManager.importJsonData("""
-{"notesData":{"version":10,"notes":{"1":{"type":0,"title":"note","content":"content","metadata":"{\"type\":\"blank\"}",
+{"version":10,"notes":{"1":{"type":0,"title":"note","content":"content","metadata":"{\"type\":\"blank\"}",
 "added":"2020-01-01T00:00:00.000Z","modified":"2020-02-01T00:00:00.000Z","status":0,"pinned":2,
-"path":"M10,10h10v10h-10Z"}},"data":"data"}}
+"path":"M10,10h10v10h-10Z"}},"data":"data"}
         """.trim().replace("\n", "")))
     }
 
     @Test
     fun testEncryptedJsonExport() = runBlocking {
+        if (shouldIgnoreEncryptionTest()) {
+            return@runBlocking
+        }
+
         prefsManager.shouldEncryptExportedData = true
         val key = encryptionSetup()
         // Since the GCM nonce is chosen at random, comparing with a static test vector isn't easily possible.
@@ -499,14 +470,16 @@ class DefaultJsonManagerTest {
 
     @Test
     fun testEncryptedJsonImportClean() = runBlocking {
+        if (shouldIgnoreEncryptionTest()) {
+            return@runBlocking
+        }
+
         val key = encryptionSetup()
         // The test data is identical to the one used in testUnencryptedJsonImportClean
         @Language("JSON") val jsonData = """{
-  "encryptedNotesData": {
     "salt": "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI",
     "nonce":"B+kFILwu8GLF1noQ",
     "ciphertext":"DwSQ5XQfkqTjhJf58JbrDZAMLhGQfnYWS4zWcrXwkkvQDAlwmE77vyatw1xem/iKqCk2oq24c1+tlOSXEiczT1JY12W6YiLN9o9v3xkYYhIrNuPTSMgtG2n8BoEpvop6Wa1ZJNlq323WnoDvlBzOUovmyzomCqrlQ8+d6xgpfBi2YPDtg+QRpUg0mCz9CBBDQuDTMdWg0UD+AucChEKwXaG0VRAKPtRFgf/qALeC4r8oPwsS3UnLsLELZGWauG8QUl7lGUzR0Ayqruk7PaEG4tOHuN3jcPBwOZHKwDZUti/Ybzn4ClKuBN2gFpTqsSYM8vhpBDz+iJ7fwLiuLAX6yvJLwiex4TACi/ZvcNTjxk2mhSaqwObbY09CbGvYgPb20N+PGdOxSxoz1LnFT6lH0XqUEgjDcIR9av8yNWx41sWNBn9Q3i43zrRe19ygzGCAgU/defKtF7pA27f905UOKY2182qqxtUIBd82Bicgd2wt3j6t7/3o9neZTawGg03pyGQt+u1S6OEt3rcmpjwEr+9PG8alCkqHQEBjqPlpSCU0aBDCV0J01Ck6MTE+qAXYEYjHdCgVpvoQ96MNGEJl3ngkhweZcF+j+Y30LG4SnGHeym18m9yzuYtOm3D6nJ0AMiM/0cB1Qkaes8Naxl/Uesusc41000Y17qNBqhbMy16KEERw3xwnzdKlfE4rSo6L/o8XLolPpHvECmQR3VPZX835O+dAilHtThqYpBMU4AktJBf1ywvH2wNoiDWYGsuTpgZ5C97kJfvk0TF7bAPQtG/KiJxDy9G/OMGsHk3D9m8x5yhvdyw5r2+N5nD/DqY0bVsyqg7+FFzD+mPk60v29PuoBautxkqyoHhkQlEIM+Z6/D6eNO6hz50+SkplJVT8f0bURMmRPcKdVaaX/1yH5ztiO3WZsyIuRpx9cCTjgX51bGuvs1gveEjkw4f/squCem/XD0GBxFoOQjIfeVs5PXsgqiSCCSMjwF1sHY71dfBbTNAiR2PsK47LlrPMsrTJBkKqZptHZy+R+u1sZ9TL/I1kvqP0yoncAPUvzcTANzPyWY1zZL3Qrv5kB/5GtNwDJ33oblHfz/MU6vE/lR5sdo1y/tU5WVLz1OC3VL15h37w0dbgcsFvSZD/pGcyCW4OVYHpIXivnO+VXZmDzjBPnap35PAa5ggRjNkgGtaU8g9NGy4xjq9bLKPvKPK+U8moIbCOQYxENEsUJBjWf/X/r+aXLFoddEVOc/DYLoBTb24O95pi5SxLLCbEcKTmfnYL4iKCsMIMaNXMPM16DBOif4BhyUH1oZZz/E4swyhe3J8vxhUPqwI2njQ"
-  }
 }
         """.trim().replace("\n", "")
         assertEquals(ImportResult.SUCCESS, jsonManager.importJsonData(jsonData, importKey = key))
@@ -546,6 +519,10 @@ class DefaultJsonManagerTest {
 
     @Test
     fun testEncryptedJsonImportMerge() = runBlocking {
+        if (shouldIgnoreEncryptionTest()) {
+            return@runBlocking
+        }
+
         val key = encryptionSetup()
 
         // insert existing data
@@ -568,11 +545,9 @@ class DefaultJsonManagerTest {
 
         // The test data is identical to the one used in testUnencryptedJsonImportMerge
         @Language("JSON") val jsonData = """{
-  "encryptedNotesData": {
     "salt": "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI",
     "nonce":"QyUp/nMOTWaJqrRv",
     "ciphertext": "/hRHbo7THTXaKaus+yF+tskMDXxOTwVWJP3eZx0hrEZllK/tYEWkd0IUctAb3kiv6GW2SLRxX7T1Y7+OAaa7HbyJmass+0tVwmh61drLobeEylEQGwLSNfvm3TBz7Von9R8S8s5B5rg4IHXC8kqVSH9PAdg9LlUqrLTLtoN8bRk4SrnOsK+Kj1RLgUhJ9SYNeKpqJaUYHHBQpy88SviMAWSksNBrWMVdMXqvT7M2JT6+0scHwboHlHn74c66YiVGM6SuCJNlQWSCFG6znXXL7xBJ8Jhc/j5JbM934ubN0Y6tU5Hu04UP0E8l65WdQGqHwIMGMtyzkSFEJuaLy011+lwssPUmgfeDDPHmRRMgoQsruhx4kTOSZ97XuHHMb7ILpYUT6CtlR443nIbrXZnTNXna6B+KlmQpmHNenKlSo9pEh0LAndOqzgn8f1nqlVPqryNt5g8hBzmZCwL89tYcZyJeJKQ6cuJNRigcJISThlNIqYdzygmENWi/bBzY8uM3ofH1zdQnm4TOfFU9oSXNbumPZYojw6kkHOOk6UAYqXIpmtOSscB94vtOhB6QSdGDiUa+9DXsMajBNy/hhvob10yG1si+ejysBjMBTgP3UTaDwarCSzDI8fkjH9pwljtSgT54AkLGVRTn4ryeFF1c0cGpjHHKqIpm2AV3qvkRLbP/TkHGkLYAnpgZXQZ14fo/jFrZTgD+YfCji0PqLi0LYirILqLIXYY3tEF4/NCVeDK1IpyQe9lryt0Hr7FWZRwiprBNL1LdL948JrjhOlJP+KLtZ0q9HABseO7Oqd8l3lNmqe2PrLyJQHkbovVqE+SJU4w7BRU9OuZ6sMfKjMJpp0PmuKE1Hspq98qlKdsTg2Pc7o89ZRX/f9hz2MyY9RJT357SmxFePGeUiDIlvhVlx4aglY451lD+gs4ubFR21eH9uA8RszXEfd52UWxFE1sHKBRJkG/BwMvPqcYgG4FMYwT+IbaM+37k9sdF7w4kYMabMeSOBK4w8fW6iZRNAdqjEToVhxRF0id17w1vB/IyaS8xcf59BVhP6hsSnpF0jebc8GeggN2XqLYrTHTbEaPraMQ2UwWk2+WBYO7QZ/it12Bv9HZ/IWCUFdjpKMZGt7EVSseVu3Fij2QZ+fhE3gMxI8EOJx4uY9FIs1bWYAQxi6/dXNm+lDHLmU7atRzN2AHQZxFN2mCd9JedLlRWX29bzG5Z8lISFShqp1eHN3BwjK41r/4BbLqAWDOMuwqiD9N+TeQGldpWd2HFTp26DlcBduXPtkzUP3dn8r+OWz77ytFNydX0LIbAVyAc4qrtJURc/yUU9uXBAsR+jOtBjzCyAVR5oz+yNLWWbhGZPaQMd3T6q0TWQAR6jAbqT1pvM9ye1iy73atSx8pJOjjyENS90k8J2y0hQGEi46I3gaXASb+8JJdQ+zS0ToRF1gbfTKfu3M4FuHa06JNC0jhg+O6qDPIl6y9Zun4WMTos6oh1PaqG951A8jdKTQ60lUSY1ygDWn074Eg3GKya2Ui+8oj6SEoRkI9ELYU77eqBOOirH/idXrnknjqAnPHpWgYir2K5gpxbkP2tzQatwB0vo/Arwjvy+MlPdVgCTVIxu+NRpQBYD10TOp00ggIfHj9lwSU6oSX5JANqIqLQ6F2Lqm8/szf8KPAm4NSz/392vnFT5cyViJxozprer8rAZnUCuv9a//dlEzozRGDFfqg+BFXNdSB5XKSNgaEnD9nVMRqHUJ4QuVcN8iuYA0Fek6SSg9eOGDVA+6fXj+2xMrhMnX7I3o8Q2w3zT0nuZtDxjdl3HdxBigsgTnRfYNyKyvJiv1XLB8IqtJCa69DXf2tTEp0938XsCjGnnXcl/w9wtShM1uwB1EiCfmNRKi7pGNTj089a/O1LIxQYQ54kMgSd2iAcMiJTtJ6b0M99JHmZ960ZTBdt0tDI0LYm+b/TT7H3OA"
-  }
 }
         """.trim().replace("\n", "")
         assertEquals(ImportResult.SUCCESS, jsonManager.importJsonData(jsonData, importKey = key))
@@ -625,34 +600,32 @@ class DefaultJsonManagerTest {
 
     @Test
     fun testEncryptedJsonImportBadData() = runBlocking {
+        if (shouldIgnoreEncryptionTest()) {
+            return@runBlocking
+        }
+
         val key = encryptionSetup()
         // invalid data (bad rrule)
         @Language("JSON") val jsonDataBadRrule = """{
-  "encryptedNotesData": {
     "salt": "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI",
     "nonce":"zk18Yk2BLLfTxMps",
     "ciphertext":"Up3FFXcXnKgpng1+nrxarmfSfEck5HxYDAGMg15LtYEtNPqCRMIFZAZ1juylZJ5YlPWoeL4wyUJl5Jypwu8IkmUljm8M1gsY16N5fyYq51OwH5LZ871+H/uXbFb58XpIEf1z075rXdTzCAzAtcrPymDNnXBGtNe42hgjStGn9qQWrRwm0IMyMjpcIfvrI3cxbuZkISiva5ec2i1/XeunW/NuKKxivHLiuTrS70WUsKm5+4zetajI9Mu+Pu2bjzkVYvU8eJD3zqqVluHpiY73a03UJFZQcf9lgZhCPCJG5pDVyLy9ieCVppTwSCRGYRmaOrf57Q+JEC24nbAKe6ULQmz1NWFuG37E6u5yTg1QZlxyK0D392oXRK9tbuW8BPYk2mLuD0sct3KKzWmIhJYaSXPPviaNRZZHROrsQayms1gJBW/NXekyreH0md5DGOD1+gdqv4WNF8hy4+HvAYyOB8EEUw"
-  }
 }
         """.trim().replace("\n", "")
         assertEquals(ImportResult.BAD_FORMAT, jsonManager.importJsonData(jsonDataBadRrule, importKey = key))
         // invalid data (missing field)
         @Language("JSON") val jsonDataMissingField = """{
-  "encryptedNotesData": {
     "salt": "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI",
     "nonce":"+2+q/POnSHNbar6L",
     "ciphertext":"hd0nyl8JKmzQq0cMxHWVumGUTTlCPAGFWODfB4iCx1xlIfdYLbgLIV+4NOjVLObxK3pJYr7eYw67NwvPYecTPbOC92S3"
-  }
 }
         """.trim().replace("\n", "")
         assertEquals(ImportResult.BAD_FORMAT, jsonManager.importJsonData(jsonDataMissingField, importKey = key))
         // invalid version number
         @Language("JSON") val jsonDataInvalidVersion = """{
-  "encryptedNotesData": {
     "salt": "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI",
     "nonce":"QsdNJ32Nao1FmUp3",
     "ciphertext":"sz4c0uiToCZ8RHSvBXI8AcVs2mFcD+oOjf5i7+Y"
-  }
 }
         """.trim().replace("\n", "")
         assertEquals(ImportResult.BAD_DATA, jsonManager.importJsonData(jsonDataInvalidVersion, importKey = key))
@@ -660,14 +633,16 @@ class DefaultJsonManagerTest {
 
     @Test
     fun testEncryptedInvalidJsonImport() = runBlocking {
+        if (shouldIgnoreEncryptionTest()) {
+            return@runBlocking
+        }
+
         val key = encryptionSetup()
         // wrong json structure
         @Language("JSON") val jsonData = """{
-  "encryptedNotesData": {
     "salt": "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI",
     "nonce":"BdnxU+ElFPIGlKJJ",
     "ciphertext":"j395X4746QzYPWEvE7nz2V0MNYzkIk+5HNrq9tsKrKI"
-  }
 }
         """.trim().replace("\n", "")
         assertEquals(ImportResult.BAD_FORMAT, jsonManager.importJsonData(jsonData, importKey = key))
@@ -675,23 +650,23 @@ class DefaultJsonManagerTest {
 
     @Test
     fun testEncryptedJsonImportWithIncorrectKey() = runBlocking {
+        if (shouldIgnoreEncryptionTest()) {
+            return@runBlocking
+        }
+
         @Language("JSON") val jsonDataWithoutKey = """{
-  "encryptedNotesData": {
     "salt": "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI",
     "nonce":"B+kFILwu8GLF1noQ",
     "ciphertext":"DwSQ5XQfkqTjhJf58JbrDZAMLhGQfnYWS4zWcrXwkkvQDAlwmE77vyatw1xem/iKqCk2oq24c1+tlOSXEiczT1JY12W6YiLN9o9v3xkYYhIrNuPTSMgtG2n8BoEpvop6Wa1ZJNlq323WnoDvlBzOUovmyzomCqrlQ8+d6xgpfBi2YPDtg+QRpUg0mCz9CBBDQuDTMdWg0UD+AucChEKwXaG0VRAKPtRFgf/qALeC4r8oPwsS3UnLsLELZGWauG8QUl7lGUzR0Ayqruk7PaEG4tOHuN3jcPBwOZHKwDZUti/Ybzn4ClKuBN2gFpTqsSYM8vhpBDz+iJ7fwLiuLAX6yvJLwiex4TACi/ZvcNTjxk2mhSaqwObbY09CbGvYgPb20N+PGdOxSxoz1LnFT6lH0XqUEgjDcIR9av8yNWx41sWNBn9Q3i43zrRe19ygzGCAgU/defKtF7pA27f905UOKY2182qqxtUIBd82Bicgd2wt3j6t7/3o9neZTawGg03pyGQt+u1S6OEt3rcmpjwEr+9PG8alCkqHQEBjqPlpSCU0aBDCV0J01Ck6MTE+qAXYEYjHdCgVpvoQ96MNGEJl3ngkhweZcF+j+Y30LG4SnGHeym18m9yzuYtOm3D6nJ0AMiM/0cB1Qkaes8Naxl/Uesusc41000Y17qNBqhbMy16KEERw3xwnzdKlfE4rSo6L/o8XLolPpHvECmQR3VPZX835O+dAilHtThqYpBMU4AktJBf1ywvH2wNoiDWYGsuTpgZ5C97kJfvk0TF7bAPQtG/KiJxDy9G/OMGsHk3D9m8x5yhvdyw5r2+N5nD/DqY0bVsyqg7+FFzD+mPk60v29PuoBautxkqyoHhkQlEIM+Z6/D6eNO6hz50+SkplJVT8f0bURMmRPcKdVaaX/1yH5ztiO3WZsyIuRpx9cCTjgX51bGuvs1gveEjkw4f/squCem/XD0GBxFoOQjIfeVs5PXsgqiSCCSMjwF1sHY71dfBbTNAiR2PsK47LlrPMsrTJBkKqZptHZy+R+u1sZ9TL/I1kvqP0yoncAPUvzcTANzPyWY1zZL3Qrv5kB/5GtNwDJ33oblHfz/MU6vE/lR5sdo1y/tU5WVLz1OC3VL15h37w0dbgcsFvSZD/pGcyCW4OVYHpIXivnO+VXZmDzjBPnap35PAa5ggRjNkgGtaU8g9NGy4xjq9bLKPvKPK+U8moIbCOQYxENEsUJBjWf/X/r+aXLFoddEVOc/DYLoBTb24O95pi5SxLLCbEcKTmfnYL4iKCsMIMaNXMPM16DBOif4BhyUH1oZZz/E4swyhe3J8vxhUPqwI2njQ"
-  }
 }
         """.trim().replace("\n", "")
         assertEquals(ImportResult.KEY_MISSING_OR_INCORRECT, jsonManager.importJsonData(jsonDataWithoutKey))
 
         val key = SecretKeySpec(ByteArray(32), KeyProperties.KEY_ALGORITHM_AES)
         @Language("JSON") val jsonDataIncorrectKey = """{
-  "encryptedNotesData": {
     "salt": "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI",
     "nonce":"B+kFILwu8GLF1noQ",
     "ciphertext":"DwSQ5XQfkqTjhJf58JbrDZAMLhGQfnYWS4zWcrXwkkvQDAlwmE77vyatw1xem/iKqCk2oq24c1+tlOSXEiczT1JY12W6YiLN9o9v3xkYYhIrNuPTSMgtG2n8BoEpvop6Wa1ZJNlq323WnoDvlBzOUovmyzomCqrlQ8+d6xgpfBi2YPDtg+QRpUg0mCz9CBBDQuDTMdWg0UD+AucChEKwXaG0VRAKPtRFgf/qALeC4r8oPwsS3UnLsLELZGWauG8QUl7lGUzR0Ayqruk7PaEG4tOHuN3jcPBwOZHKwDZUti/Ybzn4ClKuBN2gFpTqsSYM8vhpBDz+iJ7fwLiuLAX6yvJLwiex4TACi/ZvcNTjxk2mhSaqwObbY09CbGvYgPb20N+PGdOxSxoz1LnFT6lH0XqUEgjDcIR9av8yNWx41sWNBn9Q3i43zrRe19ygzGCAgU/defKtF7pA27f905UOKY2182qqxtUIBd82Bicgd2wt3j6t7/3o9neZTawGg03pyGQt+u1S6OEt3rcmpjwEr+9PG8alCkqHQEBjqPlpSCU0aBDCV0J01Ck6MTE+qAXYEYjHdCgVpvoQ96MNGEJl3ngkhweZcF+j+Y30LG4SnGHeym18m9yzuYtOm3D6nJ0AMiM/0cB1Qkaes8Naxl/Uesusc41000Y17qNBqhbMy16KEERw3xwnzdKlfE4rSo6L/o8XLolPpHvECmQR3VPZX835O+dAilHtThqYpBMU4AktJBf1ywvH2wNoiDWYGsuTpgZ5C97kJfvk0TF7bAPQtG/KiJxDy9G/OMGsHk3D9m8x5yhvdyw5r2+N5nD/DqY0bVsyqg7+FFzD+mPk60v29PuoBautxkqyoHhkQlEIM+Z6/D6eNO6hz50+SkplJVT8f0bURMmRPcKdVaaX/1yH5ztiO3WZsyIuRpx9cCTjgX51bGuvs1gveEjkw4f/squCem/XD0GBxFoOQjIfeVs5PXsgqiSCCSMjwF1sHY71dfBbTNAiR2PsK47LlrPMsrTJBkKqZptHZy+R+u1sZ9TL/I1kvqP0yoncAPUvzcTANzPyWY1zZL3Qrv5kB/5GtNwDJ33oblHfz/MU6vE/lR5sdo1y/tU5WVLz1OC3VL15h37w0dbgcsFvSZD/pGcyCW4OVYHpIXivnO+VXZmDzjBPnap35PAa5ggRjNkgGtaU8g9NGy4xjq9bLKPvKPK+U8moIbCOQYxENEsUJBjWf/X/r+aXLFoddEVOc/DYLoBTb24O95pi5SxLLCbEcKTmfnYL4iKCsMIMaNXMPM16DBOif4BhyUH1oZZz/E4swyhe3J8vxhUPqwI2njQ"
-  }
 }
         """.trim().replace("\n", "")
         assertEquals(ImportResult.KEY_MISSING_OR_INCORRECT,
@@ -700,22 +675,22 @@ class DefaultJsonManagerTest {
 
     @Test
     fun testEncryptedJsonImportWithIncorrectNonce() = runBlocking {
+        if (shouldIgnoreEncryptionTest()) {
+            return@runBlocking
+        }
+
         val key = encryptionSetup()
         @Language("JSON") val jsonDataWithoutNonce = """{
-  "encryptedNotesData": {
     "salt": "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI",
     "ciphertext":"DwSQ5XQfkqTjhJf58JbrDZAMLhGQfnYWS4zWcrXwkkvQDAlwmE77vyatw1xem/iKqCk2oq24c1+tlOSXEiczT1JY12W6YiLN9o9v3xkYYhIrNuPTSMgtG2n8BoEpvop6Wa1ZJNlq323WnoDvlBzOUovmyzomCqrlQ8+d6xgpfBi2YPDtg+QRpUg0mCz9CBBDQuDTMdWg0UD+AucChEKwXaG0VRAKPtRFgf/qALeC4r8oPwsS3UnLsLELZGWauG8QUl7lGUzR0Ayqruk7PaEG4tOHuN3jcPBwOZHKwDZUti/Ybzn4ClKuBN2gFpTqsSYM8vhpBDz+iJ7fwLiuLAX6yvJLwiex4TACi/ZvcNTjxk2mhSaqwObbY09CbGvYgPb20N+PGdOxSxoz1LnFT6lH0XqUEgjDcIR9av8yNWx41sWNBn9Q3i43zrRe19ygzGCAgU/defKtF7pA27f905UOKY2182qqxtUIBd82Bicgd2wt3j6t7/3o9neZTawGg03pyGQt+u1S6OEt3rcmpjwEr+9PG8alCkqHQEBjqPlpSCU0aBDCV0J01Ck6MTE+qAXYEYjHdCgVpvoQ96MNGEJl3ngkhweZcF+j+Y30LG4SnGHeym18m9yzuYtOm3D6nJ0AMiM/0cB1Qkaes8Naxl/Uesusc41000Y17qNBqhbMy16KEERw3xwnzdKlfE4rSo6L/o8XLolPpHvECmQR3VPZX835O+dAilHtThqYpBMU4AktJBf1ywvH2wNoiDWYGsuTpgZ5C97kJfvk0TF7bAPQtG/KiJxDy9G/OMGsHk3D9m8x5yhvdyw5r2+N5nD/DqY0bVsyqg7+FFzD+mPk60v29PuoBautxkqyoHhkQlEIM+Z6/D6eNO6hz50+SkplJVT8f0bURMmRPcKdVaaX/1yH5ztiO3WZsyIuRpx9cCTjgX51bGuvs1gveEjkw4f/squCem/XD0GBxFoOQjIfeVs5PXsgqiSCCSMjwF1sHY71dfBbTNAiR2PsK47LlrPMsrTJBkKqZptHZy+R+u1sZ9TL/I1kvqP0yoncAPUvzcTANzPyWY1zZL3Qrv5kB/5GtNwDJ33oblHfz/MU6vE/lR5sdo1y/tU5WVLz1OC3VL15h37w0dbgcsFvSZD/pGcyCW4OVYHpIXivnO+VXZmDzjBPnap35PAa5ggRjNkgGtaU8g9NGy4xjq9bLKPvKPK+U8moIbCOQYxENEsUJBjWf/X/r+aXLFoddEVOc/DYLoBTb24O95pi5SxLLCbEcKTmfnYL4iKCsMIMaNXMPM16DBOif4BhyUH1oZZz/E4swyhe3J8vxhUPqwI2njQ"
-  }
 }
         """.trim().replace("\n", "")
         assertEquals(ImportResult.BAD_FORMAT, jsonManager.importJsonData(jsonDataWithoutNonce, importKey = key))
 
         @Language("JSON") val jsonDataIncorrectNonce = """{
-  "encryptedNotesData": {
     "salt": "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI",
     "nonce":"AAAAAAAAAAAAAAAA",
     "ciphertext":"DwSQ5XQfkqTjhJf58JbrDZAMLhGQfnYWS4zWcrXwkkvQDAlwmE77vyatw1xem/iKqCk2oq24c1+tlOSXEiczT1JY12W6YiLN9o9v3xkYYhIrNuPTSMgtG2n8BoEpvop6Wa1ZJNlq323WnoDvlBzOUovmyzomCqrlQ8+d6xgpfBi2YPDtg+QRpUg0mCz9CBBDQuDTMdWg0UD+AucChEKwXaG0VRAKPtRFgf/qALeC4r8oPwsS3UnLsLELZGWauG8QUl7lGUzR0Ayqruk7PaEG4tOHuN3jcPBwOZHKwDZUti/Ybzn4ClKuBN2gFpTqsSYM8vhpBDz+iJ7fwLiuLAX6yvJLwiex4TACi/ZvcNTjxk2mhSaqwObbY09CbGvYgPb20N+PGdOxSxoz1LnFT6lH0XqUEgjDcIR9av8yNWx41sWNBn9Q3i43zrRe19ygzGCAgU/defKtF7pA27f905UOKY2182qqxtUIBd82Bicgd2wt3j6t7/3o9neZTawGg03pyGQt+u1S6OEt3rcmpjwEr+9PG8alCkqHQEBjqPlpSCU0aBDCV0J01Ck6MTE+qAXYEYjHdCgVpvoQ96MNGEJl3ngkhweZcF+j+Y30LG4SnGHeym18m9yzuYtOm3D6nJ0AMiM/0cB1Qkaes8Naxl/Uesusc41000Y17qNBqhbMy16KEERw3xwnzdKlfE4rSo6L/o8XLolPpHvECmQR3VPZX835O+dAilHtThqYpBMU4AktJBf1ywvH2wNoiDWYGsuTpgZ5C97kJfvk0TF7bAPQtG/KiJxDy9G/OMGsHk3D9m8x5yhvdyw5r2+N5nD/DqY0bVsyqg7+FFzD+mPk60v29PuoBautxkqyoHhkQlEIM+Z6/D6eNO6hz50+SkplJVT8f0bURMmRPcKdVaaX/1yH5ztiO3WZsyIuRpx9cCTjgX51bGuvs1gveEjkw4f/squCem/XD0GBxFoOQjIfeVs5PXsgqiSCCSMjwF1sHY71dfBbTNAiR2PsK47LlrPMsrTJBkKqZptHZy+R+u1sZ9TL/I1kvqP0yoncAPUvzcTANzPyWY1zZL3Qrv5kB/5GtNwDJ33oblHfz/MU6vE/lR5sdo1y/tU5WVLz1OC3VL15h37w0dbgcsFvSZD/pGcyCW4OVYHpIXivnO+VXZmDzjBPnap35PAa5ggRjNkgGtaU8g9NGy4xjq9bLKPvKPK+U8moIbCOQYxENEsUJBjWf/X/r+aXLFoddEVOc/DYLoBTb24O95pi5SxLLCbEcKTmfnYL4iKCsMIMaNXMPM16DBOif4BhyUH1oZZz/E4swyhe3J8vxhUPqwI2njQ"
-  }
 }
         """.trim().replace("\n", "")
         assertEquals(ImportResult.KEY_MISSING_OR_INCORRECT,
@@ -723,373 +698,27 @@ class DefaultJsonManagerTest {
     }
 
     @Test
+
     fun testEncryptedJsonForwardCompatibility() = runBlocking {
+        if (shouldIgnoreEncryptionTest()) {
+            return@runBlocking
+        }
+
         val key = encryptionSetup()
         // importing data with unsupported values for existing fields should fail
         @Language("JSON") val jsonData1 = """{
-  "encryptedNotesData": {
     "salt": "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI",
     "nonce":"dbIIGz5sG3qZO8/R",
     "ciphertext":"4xCyvX+WHiji0+hiGP59ykDMwVgNfYGgPRRkvg2OtFfCLhOka19A+5n5SpMNS9HSoDzbzQXORp4ijQY+R9krxkV94QvU1PcpB07mDZcslsBzLhuLTR7a0AvIO+xpCodMuq8cHDmWfGTyGZmPLlTEjAZ60tSwuHPRAPA4dM9GlwfDeL2PdXaxIsckdtipAlA8RK6jner+vbS8B3DkSY/g3v/Uo1IcHIl9cVCoCz7DKHJZfRTjlXeqVuu0ZwuD8W7ihOjzzbDABWgnTZOgk6p+1Jn5cG/O71TPNivq6cdNupugoOdyImrzUp3+HpLHxe+/Rb1puRJ1BBc7s/4nSPVM85c7nam52qyA"
-  }
 }
         """.trim().replace("\n", "")
         assertEquals(ImportResult.BAD_DATA, jsonManager.importJsonData(jsonData1, importKey = key))
         @Language("JSON") val jsonData2 = """{
-  "encryptedNotesData": {
     "salt": "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI",
     "nonce":"Qm8INVqCd49zvCJG",
     "ciphertext":"PpUonn9kBwWS3WjAgtJdUlDy2All1N7lfRMYYw8MSDDUPYZAVzeu7rOH38j2Qz5IqWlWbam4RBKP+NihH12BHkI4iPKjSHjtb+XKSNJ0niSet+5SQBmqMhU74O0/YqkuR0aBHU7Rs6TRJYR9CthXtjTvnbCWAw2wOmriOvKRw9pN3VARXf7usw1UKf1/7BNoXU5zBLhjwLZMNvCCWbBotmGM06i/Gy6mg85kBXbLIhp6BAABwiM1uCow7ivgnid50ei1M5Z+13G92QV9jcsmlXAFO/OKrCc4MsIMGAp6G/e0+6jeuEE7W6i7DWsJmlYZomSd05K6t6Pzer3ViC6u3RHE7/Q"
-  }
 }
         """.trim().replace("\n", "")
         assertEquals(ImportResult.FUTURE_VERSION, jsonManager.importJsonData(jsonData2, importKey = key))
-    }
-
-    @Test
-    fun testLegacyJsonImportClean() = runBlocking {
-        @Language("JSON") val jsonData = """{
-  "version": 3,
-  "notes": {
-    "1": {
-      "type": 0,
-      "title": "note",
-      "content": "content",
-      "metadata": "{\"type\":\"blank\"}",
-      "added": "2020-01-01T00:00:00.000Z",
-      "modified": "2020-02-01T00:00:00.000Z",
-      "status": 0,
-      "pinned": 2,
-      "reminder": {
-        "start": "2020-03-01T00:00:00.000Z",
-        "recurrence": "RRULE:FREQ=DAILY",
-        "next": "2020-03-02T00:00:00.000Z",
-        "count": 1,
-        "done": false
-      },
-      "labels": [1, 10]
-    },
-    "9": {
-      "type": 1,
-      "title": "list",
-      "content": "item 1\nitem 2",
-      "metadata": "{\"type\":\"list\",\"checked\":[false,true]}",
-      "added": "2019-01-01T00:00:00.000Z",
-      "modified": "2019-02-01T00:00:00.000Z",
-      "status": 1,
-      "pinned": 0,
-      "labels": [1, 3]
-    }
-  },
-  "labels": {
-    "1": {"name": "label0"},
-    "3": {"name": "label1"},
-    "10": {"name": "label2"}
-  }
-}
-        """.trim().replace("\n", "")
-        assertEquals(ImportResult.SUCCESS, jsonManager.importJsonData(jsonData))
-
-        val label1 = Label(1, "label0")
-        val label3 = Label(3, "label1")
-        val label10 = Label(10, "label2")
-
-        assertEquals(setOf(label1, label3, label10), labelsDao.getAll().toSet())
-
-        assertEquals(setOf(
-            NoteWithLabels(Note(id = 1,
-                type = NoteType.TEXT,
-                title = "note",
-                content = "content",
-                metadata = BlankNoteMetadata,
-                addedDate = dateFor("2020-01-01"),
-                lastModifiedDate = dateFor("2020-02-01"),
-                status = NoteStatus.ACTIVE,
-                pinned = PinnedStatus.PINNED,
-                reminder = Reminder(dateFor("2020-03-01"), Recurrence(Recurrence.Period.DAILY),
-                    dateFor("2020-03-02"), 1, false)
-            ), listOf(label1, label10)),
-            NoteWithLabels(Note(id = 9,
-                type = NoteType.LIST,
-                title = "list",
-                content = "item 1\nitem 2",
-                metadata = ListNoteMetadata(listOf(false, true)),
-                addedDate = dateFor("2019-01-01"),
-                lastModifiedDate = dateFor("2019-02-01"),
-                status = NoteStatus.ARCHIVED,
-                pinned = PinnedStatus.CANT_PIN,
-                reminder = null
-            ), listOf(label1, label3)),
-        ), notesDao.getAll().toSet())
-    }
-
-    @Test
-    fun testLegacyJsonImportMerge() = runBlocking {
-        // insert existing data
-        val label1 = Label(1, "label0")
-        val label3 = Label(3, "label3")
-        val label10 = Label(10, "label10")
-        notesDao.insertAll(listOf(
-            // merge case: same ID, no reminder on old, labels merge.
-            testNote(id = 1, added = dateFor("2020-01-01")),
-            // merge case: different dates, ID clash.
-            testNote(id = 9, added = dateFor("2021-01-01")),
-            // merge case: different reminders
-            testNote(id = 12, added = dateFor("2021-01-01"),
-                reminder = Reminder(dateFor("2021-01-02"), null, dateFor("2021-01-03"), 1, true)),
-        ))
-        labelsDao.insert(label1)
-        labelsDao.insert(label3)
-        labelsDao.insert(label10)
-        labelsDao.insertRefs(listOf(LabelRef(1, 1), LabelRef(1, 3)))
-
-        @Language("JSON") val jsonData = """{
-  "version": 3,
-  "notes": {
-    "1": {
-      "type": 0,
-      "title": "note",
-      "content": "content",
-      "metadata": "{\"type\":\"blank\"}",
-      "added": "2020-01-01T00:00:00.000Z",
-      "modified": "2020-01-01T00:00:00.000Z",
-      "status": 0,
-      "pinned": 2,
-      "reminder": {
-        "start": "2020-03-01T00:00:00.000Z",
-        "recurrence": "RRULE:FREQ=DAILY",
-        "next": "2020-03-02T00:00:00.000Z",
-        "count": 1,
-        "done": false
-      },
-      "labels": [1, 3, 9]
-    },
-    "9": {
-      "type": 1,
-      "title": "list",
-      "content": "item 1\nitem 2",
-      "metadata": "{\"type\":\"list\",\"checked\":[false,true]}",
-      "added": "2019-01-01T00:00:00.000Z",
-      "modified": "2019-02-01T00:00:00.000Z",
-      "status": 1,
-      "pinned": 0,
-      "reminder": null,
-      "labels": [
-        1,
-        9
-      ]
-    },
-    "12": {
-      "type": 0,
-      "title": "note",
-      "content": "content",
-      "metadata": "{\"type\":\"blank\"}",
-      "added": "2021-01-01T00:00:00.000Z",
-      "modified": "2021-01-01T00:00:00.000Z",
-      "status": 0,
-      "pinned": 1,
-      "reminder": {
-        "start": "2021-01-02T00:00:00.000Z",
-        "next": "2022-01-02T00:00:00.000Z",
-        "count": 1,
-        "done": false
-      }
-    }
-  },
-  "labels": {
-    "1": {"name": "label0"},
-    "3": {"name": "label11"},
-    "9": {"name": "label10"}
-  }
-}
-        """.trim().replace("\n", "")
-        assertEquals(ImportResult.SUCCESS, jsonManager.importJsonData(jsonData))
-
-        val label9 = Label(9, "label10 (2)")
-        val label11 = Label(11, "label11")
-
-        assertEquals(setOf(label1, label3, label9, label10, label11), labelsDao.getAll().toSet())
-
-        assertEquals(setOf(
-            NoteWithLabels(Note(id = 1,
-                type = NoteType.TEXT,
-                title = "note",
-                content = "content",
-                metadata = BlankNoteMetadata,
-                addedDate = dateFor("2020-01-01"),
-                lastModifiedDate = dateFor("2020-01-01"),
-                status = NoteStatus.ACTIVE,
-                pinned = PinnedStatus.PINNED,
-                reminder = Reminder(dateFor("2020-03-01"), Recurrence(Recurrence.Period.DAILY),
-                    dateFor("2020-03-02"), 1, false)
-            ), listOf(label1, label3, label9, label11)),
-            NoteWithLabels(
-                testNote(id = 9, added = dateFor("2021-01-01")),
-                emptyList()
-            ),
-            NoteWithLabels(
-                testNote(id = 12, added = dateFor("2021-01-01"),
-                    reminder = Reminder(dateFor("2021-01-02"), null, dateFor("2021-01-03"), 1, true)),
-                emptyList()
-            ),
-            NoteWithLabels(Note(id = 13,
-                type = NoteType.LIST,
-                title = "list",
-                content = "item 1\nitem 2",
-                metadata = ListNoteMetadata(listOf(false, true)),
-                addedDate = dateFor("2019-01-01"),
-                lastModifiedDate = dateFor("2019-02-01"),
-                status = NoteStatus.ARCHIVED,
-                pinned = PinnedStatus.CANT_PIN,
-                reminder = null
-            ), listOf(label1, label9)),
-            NoteWithLabels(
-                testNote(id = 14, added = dateFor("2021-01-01"),
-                    reminder = Reminder(dateFor("2021-01-02"), null, dateFor("2022-01-02"), 1, false)),
-                emptyList()
-            ),
-        ), notesDao.getAll().toSet())
-    }
-
-    @Test
-    fun testLegacyJsonImportBadData() = runBlocking {
-        // invalid data (bad rrule)
-        assertEquals(ImportResult.BAD_FORMAT, jsonManager.importJsonData("""
-{"version":3,"notes":{"1":{"type":0,"title":"note","content":"content","metadata":"{\"type\":\"blank\"}",
-"added":"2020-01-01T00:00:00.000Z","modified":"2020-02-01T00:00:00.000Z","status":0,"pinned":2,
-"reminder":{"start":"2020-03-01T00:00:00.000Z","recurrence":"RRULE:FREQ=MILKY",
-"next":"2020-03-02T00:00:00.000Z","count":1,"done":false}}}}
-        """.trim().replace("\n", "")))
-        // invalid data (missing field)
-        assertEquals(ImportResult.BAD_FORMAT, jsonManager.importJsonData("""
-{"version":3,"notes":{"1":{"type":0,"title":"note"}}}
-        """.trim().replace("\n", "")))
-        // invalid version number
-        assertEquals(ImportResult.BAD_DATA, jsonManager.importJsonData("""{"version":0}"""))
-    }
-
-    @Test
-    fun testLegacyJsonForwardCompatibility() = runBlocking {
-        // importing data with unsupported values for existing fields should fail
-        assertEquals(ImportResult.BAD_DATA, jsonManager.importJsonData("""
-{"version":11,"notes":{"1":{"type":100,"title":"note","content":"content","metadata":"{\"type\":\"drawing\"}",
-"added":"2020-01-01T00:00:00.000Z","modified":"2020-02-01T00:00:00.000Z","status":0,"pinned":2,
-"path":"M10,10h10v10h-10Z"}},"data":"data"}
-        """.trim().replace("\n", "")))
-        assertEquals(ImportResult.FUTURE_VERSION, jsonManager.importJsonData("""
-{"version":10,"notes":{"1":{"type":0,"title":"note","content":"content","metadata":"{\"type\":\"blank\"}",
-"added":"2020-01-01T00:00:00.000Z","modified":"2020-02-01T00:00:00.000Z","status":0,"pinned":2,
-"path":"M10,10h10v10h-10Z"}},"data":"data"}
-        """.trim().replace("\n", "")))
-    }
-
-    @Test
-    fun testMalformedJsonImport() = runBlocking {
-        val key = encryptionSetup()
-
-        @Language("JSON") val jsonData = """{
-  "notesData": {
-    "version": 3,
-    "notes": {
-      "1": {
-        "type": 0,
-        "title": "note",
-        "content": "content",
-        "metadata": "{\"type\":\"blank\"}",
-        "added": "2020-01-01T00:00:00.000Z",
-        "modified": "2020-02-01T00:00:00.000Z",
-        "status": 0,
-        "pinned": 2,
-        "reminder": {
-          "start": "2020-03-01T00:00:00.000Z",
-          "recurrence": "RRULE:FREQ=DAILY",
-          "next": "2020-03-02T00:00:00.000Z",
-          "count": 1,
-          "done": false
-        },
-        "labels": [1, 10]
-      },
-      "9": {
-        "type": 1,
-        "title": "list",
-        "content": "item 1\nitem 2",
-        "metadata": "{\"type\":\"list\",\"checked\":[false,true]}",
-        "added": "2019-01-01T00:00:00.000Z",
-        "modified": "2019-02-01T00:00:00.000Z",
-        "status": 1,
-        "pinned": 0,
-        "labels": [1, 3]
-      }
-    },
-    "labels": {
-      "1": {"name": "label0", "hidden": true},
-      "3": {"name": "label1"},
-      "10": {"name": "label2"}
-    }
-  },
-  "encryptedNotesData": {
-    "salt": "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI",
-    "nonce":"B+kFILwu8GLF1noQ",
-    "ciphertext":"DwSQ5XQfkqTjhJf58JbrDZAMLhGQfnYWS4zWcrXwkkvQDAlwmE77vyatw1xem/iKqCk2oq24c1+tlOSXEiczT1JY12W6YiLN9o9v3xkYYhIrNuPTSMgtG2n8BoEpvop6Wa1ZJNlq323WnoDvlBzOUovmyzomCqrlQ8+d6xgpfBi2YPDtg+QRpUg0mCz9CBBDQuDTMdWg0UD+AucChEKwXaG0VRAKPtRFgf/qALeC4r8oPwsS3UnLsLELZGWauG8QUl7lGUzR0Ayqruk7PaEG4tOHuN3jcPBwOZHKwDZUti/Ybzn4ClKuBN2gFpTqsSYM8vhpBDz+iJ7fwLiuLAX6yvJLwiex4TACi/ZvcNTjxk2mhSaqwObbY09CbGvYgPb20N+PGdOxSxoz1LnFT6lH0XqUEgjDcIR9av8yNWx41sWNBn9Q3i43zrRe19ygzGCAgU/defKtF7pA27f905UOKY2182qqxtUIBd82Bicgd2wt3j6t7/3o9neZTawGg03pyGQt+u1S6OEt3rcmpjwEr+9PG8alCkqHQEBjqPlpSCU0aBDCV0J01Ck6MTE+qAXYEYjHdCgVpvoQ96MNGEJl3ngkhweZcF+j+Y30LG4SnGHeym18m9yzuYtOm3D6nJ0AMiM/0cB1Qkaes8Naxl/Uesusc41000Y17qNBqhbMy16KEERw3xwnzdKlfE4rSo6L/o8XLolPpHvECmQR3VPZX835O+dAilHtThqYpBMU4AktJBf1ywvH2wNoiDWYGsuTpgZ5C97kJfvk0TF7bAPQtG/KiJxDy9G/OMGsHk3D9m8x5yhvdyw5r2+N5nD/DqY0bVsyqg7+FFzD+mPk60v29PuoBautxkqyoHhkQlEIM+Z6/D6eNO6hz50+SkplJVT8f0bURMmRPcKdVaaX/1yH5ztiO3WZsyIuRpx9cCTjgX51bGuvs1gveEjkw4f/squCem/XD0GBxFoOQjIfeVs5PXsgqiSCCSMjwF1sHY71dfBbTNAiR2PsK47LlrPMsrTJBkKqZptHZy+R+u1sZ9TL/I1kvqP0yoncAPUvzcTANzPyWY1zZL3Qrv5kB/5GtNwDJ33oblHfz/MU6vE/lR5sdo1y/tU5WVLz1OC3VL15h37w0dbgcsFvSZD/pGcyCW4OVYHpIXivnO+VXZmDzjBPnap35PAa5ggRjNkgGtaU8g9NGy4xjq9bLKPvKPK+U8moIbCOQYxENEsUJBjWf/X/r+aXLFoddEVOc/DYLoBTb24O95pi5SxLLCbEcKTmfnYL4iKCsMIMaNXMPM16DBOif4BhyUH1oZZz/E4swyhe3J8vxhUPqwI2njQ"
-  }
-}
-        """.trim().replace("\n", "")
-        assertEquals(ImportResult.BAD_FORMAT, jsonManager.importJsonData(jsonData, importKey = key))
-
-        @Language("JSON") val jsonData2 = """{
-  "notesData": {
-    "version": 3,
-    "notes": {
-      "1": {
-        "type": 0,
-        "title": "note",
-        "content": "content",
-        "metadata": "{\"type\":\"blank\"}",
-        "added": "2020-01-01T00:00:00.000Z",
-        "modified": "2020-02-01T00:00:00.000Z",
-        "status": 0,
-        "pinned": 2,
-        "reminder": {
-          "start": "2020-03-01T00:00:00.000Z",
-          "recurrence": "RRULE:FREQ=DAILY",
-          "next": "2020-03-02T00:00:00.000Z",
-          "count": 1,
-          "done": false
-        },
-        "labels": [1, 10]
-      },
-      "9": {
-        "type": 1,
-        "title": "list",
-        "content": "item 1\nitem 2",
-        "metadata": "{\"type\":\"list\",\"checked\":[false,true]}",
-        "added": "2019-01-01T00:00:00.000Z",
-        "modified": "2019-02-01T00:00:00.000Z",
-        "status": 1,
-        "pinned": 0,
-        "labels": [1, 3]
-      }
-    },
-    "labels": {
-      "1": {"name": "label0", "hidden": true},
-      "3": {"name": "label1"},
-      "10": {"name": "label2"}
-    }
-  },
-  "version": 3
-}
-        """.trim().replace("\n", "")
-        assertEquals(ImportResult.BAD_FORMAT, jsonManager.importJsonData(jsonData2))
-
-        @Language("JSON") val jsonData3 = """{
-  "encryptedNotesData": {
-    "salt": "Wk7ITADlYDBTP/o8GtupJyWemvDClrDNxXKhoMBuTIp8QjlAlPdVAWfAi+B3GWTn/YmqgBP3OCK20Vmcm9hQbzwNfnXsnChnPu462ALv+WKf8y2NirINyWr5jG/tAOaE6bGNL+ZE4ClppTdBt82Gl87q6FX0pFqhJtmrE+8jLmI",
-    "nonce":"B+kFILwu8GLF1noQ",
-    "ciphertext":"DwSQ5XQfkqTjhJf58JbrDZAMLhGQfnYWS4zWcrXwkkvQDAlwmE77vyatw1xem/iKqCk2oq24c1+tlOSXEiczT1JY12W6YiLN9o9v3xkYYhIrNuPTSMgtG2n8BoEpvop6Wa1ZJNlq323WnoDvlBzOUovmyzomCqrlQ8+d6xgpfBi2YPDtg+QRpUg0mCz9CBBDQuDTMdWg0UD+AucChEKwXaG0VRAKPtRFgf/qALeC4r8oPwsS3UnLsLELZGWauG8QUl7lGUzR0Ayqruk7PaEG4tOHuN3jcPBwOZHKwDZUti/Ybzn4ClKuBN2gFpTqsSYM8vhpBDz+iJ7fwLiuLAX6yvJLwiex4TACi/ZvcNTjxk2mhSaqwObbY09CbGvYgPb20N+PGdOxSxoz1LnFT6lH0XqUEgjDcIR9av8yNWx41sWNBn9Q3i43zrRe19ygzGCAgU/defKtF7pA27f905UOKY2182qqxtUIBd82Bicgd2wt3j6t7/3o9neZTawGg03pyGQt+u1S6OEt3rcmpjwEr+9PG8alCkqHQEBjqPlpSCU0aBDCV0J01Ck6MTE+qAXYEYjHdCgVpvoQ96MNGEJl3ngkhweZcF+j+Y30LG4SnGHeym18m9yzuYtOm3D6nJ0AMiM/0cB1Qkaes8Naxl/Uesusc41000Y17qNBqhbMy16KEERw3xwnzdKlfE4rSo6L/o8XLolPpHvECmQR3VPZX835O+dAilHtThqYpBMU4AktJBf1ywvH2wNoiDWYGsuTpgZ5C97kJfvk0TF7bAPQtG/KiJxDy9G/OMGsHk3D9m8x5yhvdyw5r2+N5nD/DqY0bVsyqg7+FFzD+mPk60v29PuoBautxkqyoHhkQlEIM+Z6/D6eNO6hz50+SkplJVT8f0bURMmRPcKdVaaX/1yH5ztiO3WZsyIuRpx9cCTjgX51bGuvs1gveEjkw4f/squCem/XD0GBxFoOQjIfeVs5PXsgqiSCCSMjwF1sHY71dfBbTNAiR2PsK47LlrPMsrTJBkKqZptHZy+R+u1sZ9TL/I1kvqP0yoncAPUvzcTANzPyWY1zZL3Qrv5kB/5GtNwDJ33oblHfz/MU6vE/lR5sdo1y/tU5WVLz1OC3VL15h37w0dbgcsFvSZD/pGcyCW4OVYHpIXivnO+VXZmDzjBPnap35PAa5ggRjNkgGtaU8g9NGy4xjq9bLKPvKPK+U8moIbCOQYxENEsUJBjWf/X/r+aXLFoddEVOc/DYLoBTb24O95pi5SxLLCbEcKTmfnYL4iKCsMIMaNXMPM16DBOif4BhyUH1oZZz/E4swyhe3J8vxhUPqwI2njQ"
-  },
-  "version": 3
-}
-        """.trim().replace("\n", "")
-        assertEquals(ImportResult.BAD_FORMAT, jsonManager.importJsonData(jsonData3, importKey = key))
     }
 }

--- a/app/src/main/kotlin/com/maltaisn/notes/DialogExtensions.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/DialogExtensions.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 Nicolas Maltais
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.maltaisn.notes
+
+import android.annotation.SuppressLint
+import android.app.Dialog
+import android.graphics.Rect
+import android.view.View
+import android.widget.FrameLayout
+import android.widget.TextView
+import androidx.annotation.StringRes
+import androidx.fragment.app.DialogFragment
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+
+/**
+ * Set [this] dialog maximum width to [maxWidth].
+ * @param view The dialog's content view.
+ */
+fun Dialog.setMaxWidth(maxWidth: Int, view: View) {
+    // Get current dialog's width and padding
+    val fgPadding = Rect()
+    val window = this.window!!
+    window.decorView.background.getPadding(fgPadding)
+    val padding = fgPadding.left + fgPadding.right
+    var width = this.context.resources.displayMetrics.widthPixels - padding
+
+    // Set dialog's dimensions, with maximum width.
+    if (width > maxWidth) {
+        width = maxWidth
+    }
+    window.setLayout(width + padding, FrameLayout.LayoutParams.WRAP_CONTENT)
+    view.layoutParams = FrameLayout.LayoutParams(width, FrameLayout.LayoutParams.WRAP_CONTENT)
+}
+
+/**
+ * Set title on dialog, but only if the device vertical size is large enough.
+ * Otherwise, it becomes much harder or even impossible to type text (see #53).
+ */
+fun MaterialAlertDialogBuilder.setTitleIfEnoughSpace(@StringRes title: Int): MaterialAlertDialogBuilder {
+    val dimen = context.resources.getDimension(R.dimen.input_dialog_title_min_height) /
+            context.resources.displayMetrics.density
+    if (context.resources.configuration.screenHeightDp >= dimen) {
+        setTitle(title)
+    }
+    return this
+}
+
+/**
+ * In dialogs with an EditText, the cursor must be hidden when dialog is dismissed to prevent memory leak.
+ * See [https://stackoverflow.com/questions/36842805/dialogfragment-leaking-memory].
+ * This should be called in [DialogFragment.onDismiss].
+ */
+@SuppressLint("WrongConstant")
+fun DialogFragment.hideCursorInAllViews() {
+    val view = dialog?.window?.decorView ?: return
+    for (focusableView in view.getFocusables(View.FOCUSABLES_ALL)) {
+        if (focusableView is TextView) {
+            focusableView.isCursorVisible = false
+        }
+    }
+}

--- a/app/src/main/kotlin/com/maltaisn/notes/FragmentExtensions.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/FragmentExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Nicolas Maltais
+ * Copyright 2023 Nicolas Maltais
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,33 +16,9 @@
 
 package com.maltaisn.notes
 
-import android.app.Dialog
-import android.graphics.Rect
-import android.view.View
-import android.widget.FrameLayout
 import androidx.fragment.app.FragmentManager
 
 /**
  * Returns whether this fragment manager contains a fragment with a [tag].
  */
 operator fun FragmentManager.contains(tag: String) = this.findFragmentByTag(tag) != null
-
-/**
- * Set [this] dialog maximum width to [maxWidth].
- * @param view The dialog's content view.
- */
-fun Dialog.setMaxWidth(maxWidth: Int, view: View) {
-    // Get current dialog's width and padding
-    val fgPadding = Rect()
-    val window = this.window!!
-    window.decorView.background.getPadding(fgPadding)
-    val padding = fgPadding.left + fgPadding.right
-    var width = this.context.resources.displayMetrics.widthPixels - padding
-
-    // Set dialog's dimensions, with maximum width.
-    if (width > maxWidth) {
-        width = maxWidth
-    }
-    window.setLayout(width + padding, FrameLayout.LayoutParams.WRAP_CONTENT)
-    view.layoutParams = FrameLayout.LayoutParams(width, FrameLayout.LayoutParams.WRAP_CONTENT)
-}

--- a/app/src/main/kotlin/com/maltaisn/notes/di/AppComponent.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/di/AppComponent.kt
@@ -27,6 +27,8 @@ import com.maltaisn.notes.ui.main.MainActivity
 import com.maltaisn.notes.ui.notification.NotificationActivity
 import com.maltaisn.notes.ui.reminder.ReminderDialog
 import com.maltaisn.notes.ui.search.SearchFragment
+import com.maltaisn.notes.ui.settings.ExportPasswordDialog
+import com.maltaisn.notes.ui.settings.ImportPasswordDialog
 import com.maltaisn.notes.ui.settings.SettingsFragment
 import com.maltaisn.notes.ui.sort.SortDialog
 import dagger.BindsInstance
@@ -50,6 +52,8 @@ interface AppComponent {
     fun inject(dialog: ReminderDialog)
     fun inject(dialog: LabelEditDialog)
     fun inject(dialog: SortDialog)
+    fun inject(dialog: ExportPasswordDialog)
+    fun inject(dialog: ImportPasswordDialog)
     fun inject(receiver: AlarmReceiver)
 
     @Component.Factory

--- a/app/src/main/kotlin/com/maltaisn/notes/model/DefaultJsonManager.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/model/DefaultJsonManager.kt
@@ -104,7 +104,6 @@ class DefaultJsonManager @Inject constructor(
         // Encrypt notesData
         val ciphertext = cipher.doFinal(json.encodeToString(notesData).toByteArray(Charsets.UTF_8))
 
-        // Generate BackupData object
         return EncryptedNotesData(
             salt = prefs.encryptedExportKeyDerivationSalt,
             nonce = Base64.encodeToString(cipher.iv, BASE64_FLAGS),

--- a/app/src/main/kotlin/com/maltaisn/notes/model/DefaultJsonManager.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/model/DefaultJsonManager.kt
@@ -123,7 +123,7 @@ class DefaultJsonManager @Inject constructor(
         }
 
         // If both legacy data as well as data of the new format is present, the file is considered malformed
-        if (backupData.version != null && backupData.notesData != null) {
+        if (backupData.version != null && (backupData.notesData != null || backupData.encryptedNotesData != null)) {
             return ImportResult.BAD_FORMAT
         }
 

--- a/app/src/main/kotlin/com/maltaisn/notes/model/JsonManager.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/model/JsonManager.kt
@@ -16,6 +16,8 @@
 
 package com.maltaisn.notes.model
 
+import javax.crypto.SecretKey
+
 interface JsonManager {
 
     /**
@@ -25,7 +27,7 @@ interface JsonManager {
 
     /**
      * Import notes data from JSON, merging with existing data.
-     * Returns true if import was succesfull, false otherwise.
+     * Returns true if import was successful, false otherwise.
      */
-    suspend fun importJsonData(data: String): DefaultJsonManager.ImportResult
+    suspend fun importJsonData(data: String, importKey: SecretKey? = null): DefaultJsonManager.ImportResult
 }

--- a/app/src/main/kotlin/com/maltaisn/notes/model/JsonManager.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/model/JsonManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Nicolas Maltais
+ * Copyright 2023 Nicolas Maltais
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,5 +29,13 @@ interface JsonManager {
      * Import notes data from JSON, merging with existing data.
      * Returns true if import was successful, false otherwise.
      */
-    suspend fun importJsonData(data: String, importKey: SecretKey? = null): DefaultJsonManager.ImportResult
+    suspend fun importJsonData(data: String, importKey: SecretKey? = null): ImportResult
+
+    enum class ImportResult {
+        SUCCESS,
+        BAD_FORMAT,
+        BAD_DATA,
+        FUTURE_VERSION,
+        KEY_MISSING_OR_INCORRECT,
+    }
 }

--- a/app/src/main/kotlin/com/maltaisn/notes/model/PrefsManager.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/model/PrefsManager.kt
@@ -55,6 +55,9 @@ class PrefsManager @Inject constructor(
     var sortField: SortField by enumPreference(SORT_FIELD, SortField.MODIFIED_DATE)
     var sortDirection: SortDirection by enumPreference(SORT_DIRECTION, SortDirection.DESCENDING)
 
+    var shouldEncryptExportedData: Boolean by preference(ENCRYPTED_EXPORT, false)
+    var encryptedExportKeyDerivationSalt: String by preference(ENCRYPTED_EXPORT_KEY_DERIVATION_SALT, "")
+    var encryptedImportKeyDerivationSalt: String by preference(ENCRYPTED_IMPORT_KEY_DERIVATION_SALT, "")
     var shouldAutoExport: Boolean by preference(AUTO_EXPORT, false)
     var autoExportUri: String by preference(AUTO_EXPORT_URI, "")
     var autoExportFailed: Boolean by preference(AUTO_EXPORT_FAILED, false)
@@ -178,6 +181,7 @@ class PrefsManager @Inject constructor(
         const val SHOWN_DATE = "shown_date"
         const val SWIPE_ACTION_LEFT = "swipe_action_left"
         const val SWIPE_ACTION_RIGHT = "swipe_action_right"
+        const val ENCRYPTED_EXPORT = "encrypted_export"
         const val EXPORT_DATA = "export_data"
         const val AUTO_EXPORT = "auto_export"
         const val IMPORT_DATA = "import_data"
@@ -194,6 +198,8 @@ class PrefsManager @Inject constructor(
         private const val LAST_RESTRICTED_BATTERY_REMIND_TIME = "last_restricted_battery_remind_time"
         private const val LAST_AUTO_EXPORT_TIME = "last_auto_export_time"
         private const val AUTO_EXPORT_FAILED = "auto_export_failed"
+        private const val ENCRYPTED_EXPORT_KEY_DERIVATION_SALT = "encrypted_export_key_derivation_salt"
+        private const val ENCRYPTED_IMPORT_KEY_DERIVATION_SALT = "encrypted_import_key_derivation_salt"
 
         // Legacy keys
         private const val SWIPE_ACTION = "swipe_action"

--- a/app/src/main/kotlin/com/maltaisn/notes/ui/edit/LinkArrowKeyMovementMethod.java
+++ b/app/src/main/kotlin/com/maltaisn/notes/ui/edit/LinkArrowKeyMovementMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Nicolas Maltais
+ * Copyright 2023 Nicolas Maltais
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -147,10 +147,12 @@ public class LinkArrowKeyMovementMethod extends ArrowKeyMovementMethod {
             }
         }
 
-        if (selStart > last)
+        if (selStart > last) {
             selStart = selEnd = Integer.MAX_VALUE;
-        if (selEnd < first)
+        }
+        if (selEnd < first) {
             selStart = selEnd = -1;
+        }
 
         switch (what) {
             case CLICK:
@@ -283,9 +285,9 @@ public class LinkArrowKeyMovementMethod extends ArrowKeyMovementMethod {
     }
 
     public static MovementMethod getInstance() {
-        if (sInstance == null)
+        if (sInstance == null) {
             sInstance = new LinkArrowKeyMovementMethod();
-
+        }
         return sInstance;
     }
 

--- a/app/src/main/kotlin/com/maltaisn/notes/ui/labels/LabelEditDialog.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/ui/labels/LabelEditDialog.kt
@@ -19,7 +19,6 @@ package com.maltaisn.notes.ui.labels
 import android.app.Dialog
 import android.content.DialogInterface
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.WindowManager
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.DialogFragment
@@ -28,7 +27,9 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.maltaisn.notes.App
 import com.maltaisn.notes.R
 import com.maltaisn.notes.databinding.DialogLabelEditBinding
+import com.maltaisn.notes.hideCursorInAllViews
 import com.maltaisn.notes.model.entity.Label
+import com.maltaisn.notes.setTitleIfEnoughSpace
 import com.maltaisn.notes.ui.SharedViewModel
 import com.maltaisn.notes.ui.navGraphViewModel
 import com.maltaisn.notes.ui.observeEvent
@@ -56,7 +57,7 @@ class LabelEditDialog : DialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val context = requireContext()
-        val binding = DialogLabelEditBinding.inflate(LayoutInflater.from(context), null, false)
+        val binding = DialogLabelEditBinding.inflate(layoutInflater, null, false)
 
         // Using `this` as lifecycle owner, cannot show dialog twice with same instance to avoid double observation.
         debugCheck(!viewModel.setLabelEvent.hasObservers()) { "Dialog was shown twice with same instance." }
@@ -71,18 +72,11 @@ class LabelEditDialog : DialogFragment() {
                 viewModel.addLabel()
             }
             .setNegativeButton(R.string.action_cancel, null)
-
-        // Only show dialog title if screen size is under a certain dimension.
-        // Otherwise it becomes much harder to type text, see #53.
-        val dimen = context.resources.getDimension(R.dimen.label_edit_dialog_title_min_height) /
-                context.resources.displayMetrics.density
-        if (context.resources.configuration.screenHeightDp >= dimen) {
-            builder.setTitle(if (args.labelId == Label.NO_ID) {
+            .setTitleIfEnoughSpace(if (args.labelId == Label.NO_ID) {
                 R.string.label_create
             } else {
                 R.string.label_edit
             })
-        }
 
         val dialog = builder.create()
 
@@ -103,13 +97,7 @@ class LabelEditDialog : DialogFragment() {
             viewModel.onHiddenChanged(isChecked)
         }
 
-        // Cursor must be hidden when dialog is dimissed to prevent memory leak
-        // See [https://stackoverflow.com/questions/36842805/dialogfragment-leaking-memory]
         nameInput.isCursorVisible = true
-        dialog.setOnDismissListener {
-            nameInput.isCursorVisible = false
-        }
-
         nameInput.doAfterTextChanged {
             viewModel.onNameChanged(it?.toString() ?: "")
         }
@@ -125,5 +113,10 @@ class LabelEditDialog : DialogFragment() {
         viewModel.start(args.labelId)
 
         return dialog
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+        hideCursorInAllViews()
     }
 }

--- a/app/src/main/kotlin/com/maltaisn/notes/ui/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/ui/main/MainViewModel.kt
@@ -232,8 +232,8 @@ class MainViewModel @AssistedInject constructor(
     fun autoExport(output: OutputStream?) {
         if (output != null) {
             viewModelScope.launch(Dispatchers.IO) {
-                val jsonData = jsonManager.exportJsonData()
                 prefsManager.autoExportFailed = try {
+                    val jsonData = jsonManager.exportJsonData()
                     output.use {
                         output.write(jsonData.toByteArray())
                     }

--- a/app/src/main/kotlin/com/maltaisn/notes/ui/settings/ExportPasswordDialog.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/ui/settings/ExportPasswordDialog.kt
@@ -1,10 +1,24 @@
+/*
+ * Copyright 2023 Nicolas Maltais
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.maltaisn.notes.ui.settings
 
 import android.app.Dialog
 import android.content.DialogInterface
 import android.os.Bundle
-import android.text.method.PasswordTransformationMethod
-import android.view.LayoutInflater
 import android.view.WindowManager
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.DialogFragment
@@ -12,6 +26,8 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.maltaisn.notes.App
 import com.maltaisn.notes.R
 import com.maltaisn.notes.databinding.DialogExportPasswordBinding
+import com.maltaisn.notes.hideCursorInAllViews
+import com.maltaisn.notes.setTitleIfEnoughSpace
 import com.maltaisn.notes.ui.observeEvent
 import com.maltaisn.notes.ui.viewModel
 import javax.inject.Inject
@@ -29,12 +45,11 @@ class ExportPasswordDialog : DialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val context = requireContext()
-        val binding = DialogExportPasswordBinding.inflate(LayoutInflater.from(context), null, false)
+        val binding = DialogExportPasswordBinding.inflate(layoutInflater, null, false)
 
         val passwordInput = binding.passwordInput
         val passwordRepeatInput = binding.passwordRepeat
         val passwordRepeatLayout = binding.passwordRepeatLayout
-        val showPasswordCheckbox = binding.showPasswordChk
 
         val builder = MaterialAlertDialogBuilder(context)
             .setView(binding.root)
@@ -45,14 +60,7 @@ class ExportPasswordDialog : DialogFragment() {
             .setNegativeButton(R.string.action_cancel) { _, _ ->
                 callback.onExportPasswordDialogNegativeButtonClicked()
             }
-
-        // Only show dialog title if screen size is under a certain dimension.
-        // Otherwise it becomes much harder to type text, see #53.
-        val dimen = context.resources.getDimension(R.dimen.label_edit_dialog_title_min_height) /
-                context.resources.displayMetrics.density
-        if (context.resources.configuration.screenHeightDp >= dimen) {
-            builder.setTitle(R.string.encrypted_export_dialog_title)
-        }
+            .setTitleIfEnoughSpace(R.string.encrypted_export_dialog_title)
 
         val dialog = builder.create()
         dialog.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE)
@@ -72,19 +80,6 @@ class ExportPasswordDialog : DialogFragment() {
             }
         }
 
-        showPasswordCheckbox.setOnCheckedChangeListener { _, isChecked ->
-            val transformationMethod = if (isChecked) null else PasswordTransformationMethod()
-            passwordInput.transformationMethod = transformationMethod
-            passwordRepeatInput.transformationMethod = transformationMethod
-        }
-
-        // Cursor must be hidden when dialog is dismissed to prevent memory leak
-        // See [https://stackoverflow.com/questions/36842805/dialogfragment-leaking-memory]
-        dialog.setOnDismissListener {
-            passwordInput.isCursorVisible = false
-            passwordRepeatInput.isCursorVisible = false
-        }
-
         passwordInput.doAfterTextChanged {
             viewModel.onPasswordChanged(it?.toString() ?: "", passwordRepeatInput.text.toString())
         }
@@ -100,6 +95,11 @@ class ExportPasswordDialog : DialogFragment() {
         viewModel.start()
 
         return dialog
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+        hideCursorInAllViews()
     }
 
     override fun onCancel(dialog: DialogInterface) {

--- a/app/src/main/kotlin/com/maltaisn/notes/ui/settings/ExportPasswordDialog.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/ui/settings/ExportPasswordDialog.kt
@@ -1,0 +1,126 @@
+package com.maltaisn.notes.ui.settings
+
+import android.app.Dialog
+import android.content.DialogInterface
+import android.os.Bundle
+import android.text.method.PasswordTransformationMethod
+import android.view.LayoutInflater
+import android.view.WindowManager
+import androidx.core.widget.doAfterTextChanged
+import androidx.fragment.app.DialogFragment
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.maltaisn.notes.App
+import com.maltaisn.notes.sync.R
+import com.maltaisn.notes.sync.databinding.DialogExportPasswordBinding
+import com.maltaisn.notes.ui.observeEvent
+import com.maltaisn.notes.ui.viewModel
+import javax.inject.Inject
+
+class ExportPasswordDialog : DialogFragment() {
+
+    @Inject
+    lateinit var viewModelFactory: ExportPasswordViewModel.Factory
+    val viewModel by viewModel { viewModelFactory.create(it) }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        (requireContext().applicationContext as App).appComponent.inject(this)
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val context = requireContext()
+        val binding = DialogExportPasswordBinding.inflate(LayoutInflater.from(context), null, false)
+
+        val passwordInput = binding.passwordInput
+        val passwordRepeatInput = binding.passwordRepeat
+        val passwordRepeatLayout = binding.passwordRepeatLayout
+        val showPasswordCheckbox = binding.showPasswordChk
+
+        val builder = MaterialAlertDialogBuilder(context)
+            .setView(binding.root)
+            .setPositiveButton(R.string.action_ok) { _, _ ->
+                val selectedPassword = passwordInput.text.toString()
+                callback.onExportPasswordDialogPositiveButtonClicked(selectedPassword)
+            }
+            .setNegativeButton(R.string.action_cancel) { _, _ ->
+                callback.onExportPasswordDialogNegativeButtonClicked()
+            }
+
+        // Only show dialog title if screen size is under a certain dimension.
+        // Otherwise it becomes much harder to type text, see #53.
+        val dimen = context.resources.getDimension(R.dimen.label_edit_dialog_title_min_height) /
+                context.resources.displayMetrics.density
+        if (context.resources.configuration.screenHeightDp >= dimen) {
+            builder.setTitle(R.string.encrypted_export_dialog_title)
+        }
+
+        val dialog = builder.create()
+        dialog.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE)
+        dialog.setCanceledOnTouchOutside(true)
+
+        dialog.setOnShowListener {
+            val okBtn = dialog.getButton(DialogInterface.BUTTON_POSITIVE)
+            viewModel.passwordValid.observe(this) { isPasswordValid ->
+                okBtn.isEnabled = isPasswordValid
+            }
+            viewModel.passwordRepeatErrorShown.observe(this) { shouldShowError ->
+                passwordRepeatLayout.error = if (shouldShowError) {
+                    getString(R.string.encrypted_export_password_matching_error)
+                } else {
+                    ""
+                }
+            }
+        }
+
+        showPasswordCheckbox.setOnCheckedChangeListener { _, isChecked ->
+            val transformationMethod = if (isChecked) null else PasswordTransformationMethod()
+            passwordInput.transformationMethod = transformationMethod
+            passwordRepeatInput.transformationMethod = transformationMethod
+        }
+
+        // Cursor must be hidden when dialog is dismissed to prevent memory leak
+        // See [https://stackoverflow.com/questions/36842805/dialogfragment-leaking-memory]
+        dialog.setOnDismissListener {
+            passwordInput.isCursorVisible = false
+            passwordRepeatInput.isCursorVisible = false
+        }
+
+        passwordInput.doAfterTextChanged {
+            viewModel.onPasswordChanged(it?.toString() ?: "", passwordRepeatInput.text.toString())
+        }
+        passwordRepeatInput.doAfterTextChanged {
+            viewModel.onPasswordChanged(passwordInput.text.toString(), it?.toString() ?: "")
+        }
+        passwordInput.requestFocus()
+        viewModel.setDialogDataEvent.observeEvent(this) { (password, passwordRepeat) ->
+            passwordInput.setText(password)
+            passwordRepeatInput.setText(passwordRepeat)
+        }
+
+        viewModel.start()
+
+        return dialog
+    }
+
+    override fun onCancel(dialog: DialogInterface) {
+        super.onCancel(dialog)
+        callback.onExportPasswordDialogCancelled()
+    }
+
+    private val callback: Callback
+        get() = (parentFragment as? Callback)
+            ?: (activity as? Callback)
+            ?: error("No callback for ExportPasswordDialog")
+
+    interface Callback {
+        fun onExportPasswordDialogPositiveButtonClicked(password: String) = Unit
+        fun onExportPasswordDialogNegativeButtonClicked() = Unit
+        fun onExportPasswordDialogCancelled() = Unit
+    }
+
+    companion object {
+        fun newInstance(): ExportPasswordDialog {
+            return ExportPasswordDialog()
+        }
+    }
+}

--- a/app/src/main/kotlin/com/maltaisn/notes/ui/settings/ExportPasswordDialog.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/ui/settings/ExportPasswordDialog.kt
@@ -10,8 +10,8 @@ import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.DialogFragment
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.maltaisn.notes.App
-import com.maltaisn.notes.sync.R
-import com.maltaisn.notes.sync.databinding.DialogExportPasswordBinding
+import com.maltaisn.notes.R
+import com.maltaisn.notes.databinding.DialogExportPasswordBinding
 import com.maltaisn.notes.ui.observeEvent
 import com.maltaisn.notes.ui.viewModel
 import javax.inject.Inject

--- a/app/src/main/kotlin/com/maltaisn/notes/ui/settings/ExportPasswordDialog.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/ui/settings/ExportPasswordDialog.kt
@@ -19,10 +19,13 @@ package com.maltaisn.notes.ui.settings
 import android.app.Dialog
 import android.content.DialogInterface
 import android.os.Bundle
+import android.text.method.PasswordTransformationMethod
+import android.view.View.OnClickListener
 import android.view.WindowManager
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.DialogFragment
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.textfield.TextInputLayout
 import com.maltaisn.notes.App
 import com.maltaisn.notes.R
 import com.maltaisn.notes.databinding.DialogExportPasswordBinding
@@ -48,6 +51,7 @@ class ExportPasswordDialog : DialogFragment() {
         val binding = DialogExportPasswordBinding.inflate(layoutInflater, null, false)
 
         val passwordInput = binding.passwordInput
+        val passwordLayout = binding.passwordInputLayout
         val passwordRepeatInput = binding.passwordRepeat
         val passwordRepeatLayout = binding.passwordRepeatLayout
 
@@ -87,6 +91,15 @@ class ExportPasswordDialog : DialogFragment() {
             viewModel.onPasswordChanged(passwordInput.text.toString(), it?.toString() ?: "")
         }
         passwordInput.requestFocus()
+
+        val passwordToggleListener = OnClickListener {
+            passwordLayout.togglePasswordVisibile()
+            passwordRepeatLayout.togglePasswordVisibile()
+        }
+        passwordLayout.setEndIconOnClickListener(passwordToggleListener)
+        passwordRepeatLayout.setEndIconOnClickListener(passwordToggleListener)
+        passwordRepeatLayout.setErrorIconOnClickListener(passwordToggleListener)
+
         viewModel.setDialogDataEvent.observeEvent(this) { (password, passwordRepeat) ->
             passwordInput.setText(password)
             passwordRepeatInput.setText(passwordRepeat)
@@ -95,6 +108,23 @@ class ExportPasswordDialog : DialogFragment() {
         viewModel.start()
 
         return dialog
+    }
+
+    private fun TextInputLayout.togglePasswordVisibile() {
+        val editText = editText ?: return
+        // Store the current cursor position
+        val selection = editText.selectionEnd
+
+        // Check for existing password transformation
+        val hasPasswordTransformation = editText.transformationMethod is PasswordTransformationMethod;
+        if (hasPasswordTransformation) {
+            editText.transformationMethod = null
+        } else {
+            editText.transformationMethod = PasswordTransformationMethod.getInstance()
+        }
+
+        // Restore the cursor position
+        editText.setSelection(selection)
     }
 
     override fun onDismiss(dialog: DialogInterface) {

--- a/app/src/main/kotlin/com/maltaisn/notes/ui/settings/ExportPasswordViewModel.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/ui/settings/ExportPasswordViewModel.kt
@@ -1,0 +1,65 @@
+package com.maltaisn.notes.ui.settings
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import com.maltaisn.notes.ui.AssistedSavedStateViewModelFactory
+import com.maltaisn.notes.ui.Event
+import com.maltaisn.notes.ui.send
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+
+class ExportPasswordViewModel @AssistedInject constructor(
+    @Assisted private val savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val _setDialogDataEvent = MutableLiveData<Event<Pair<String, String>>>()
+    val setDialogDataEvent: LiveData<Event<Pair<String, String>>>
+        get() = _setDialogDataEvent
+
+    private val _passwordValid = MutableLiveData(false)
+    val passwordValid: LiveData<Boolean>
+        get() = _passwordValid
+
+    private val _passwordRepeatErrorShown = MutableLiveData(false)
+    val passwordRepeatErrorShown: LiveData<Boolean>
+        get() = _passwordRepeatErrorShown
+
+    private var password = savedStateHandle[KEY_PASSWORD] ?: ""
+        set(value) {
+            field = value
+            savedStateHandle[KEY_PASSWORD] = value
+        }
+
+    private var passwordRepeat = savedStateHandle[KEY_PASSWORD_REPEAT] ?: ""
+        set(value) {
+            field = value
+            savedStateHandle[KEY_PASSWORD_REPEAT] = value
+        }
+
+    fun start() {
+        if (KEY_PASSWORD in savedStateHandle || KEY_PASSWORD_REPEAT in savedStateHandle) {
+            _setDialogDataEvent.send(Pair(this.password, this.passwordRepeat))
+        }
+    }
+
+    fun onPasswordChanged(password: String, passwordRepeat: String) {
+        // Check if passwords match. Also don't allow empty passwords
+        _passwordValid.value = (password == passwordRepeat) && password.isNotEmpty()
+        _passwordRepeatErrorShown.value = password != passwordRepeat
+        this.password = password
+        this.passwordRepeat = passwordRepeat
+    }
+
+    @AssistedFactory
+    interface Factory : AssistedSavedStateViewModelFactory<ExportPasswordViewModel> {
+        override fun create(savedStateHandle: SavedStateHandle): ExportPasswordViewModel
+    }
+
+    companion object {
+        private const val KEY_PASSWORD = "password"
+        private const val KEY_PASSWORD_REPEAT = "passwordRepeat"
+    }
+}

--- a/app/src/main/kotlin/com/maltaisn/notes/ui/settings/ImportPasswordDialog.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/ui/settings/ImportPasswordDialog.kt
@@ -1,0 +1,107 @@
+package com.maltaisn.notes.ui.settings
+
+import android.app.Dialog
+import android.content.DialogInterface
+import android.os.Bundle
+import android.text.method.PasswordTransformationMethod
+import android.view.LayoutInflater
+import android.view.WindowManager
+import androidx.core.widget.doAfterTextChanged
+import androidx.fragment.app.DialogFragment
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.maltaisn.notes.App
+import com.maltaisn.notes.sync.R
+import com.maltaisn.notes.sync.databinding.DialogImportPasswordBinding
+import com.maltaisn.notes.ui.observeEvent
+import com.maltaisn.notes.ui.viewModel
+import javax.inject.Inject
+
+class ImportPasswordDialog : DialogFragment() {
+
+    @Inject
+    lateinit var viewModelFactory: ImportPasswordViewModel.Factory
+    val viewModel by viewModel { viewModelFactory.create(it) }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        (requireContext().applicationContext as App).appComponent.inject(this)
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val context = requireContext()
+        val binding = DialogImportPasswordBinding.inflate(LayoutInflater.from(context), null, false)
+
+        val passwordInput = binding.passwordInput
+        val showPasswordCheckbox = binding.showPasswordChk
+
+        val builder = MaterialAlertDialogBuilder(context)
+            .setView(binding.root)
+            .setPositiveButton(R.string.action_ok) { _, _ ->
+                val selectedPassword = passwordInput.text.toString()
+                callback.onImportPasswordDialogPositiveButtonClicked(selectedPassword)
+            }
+            .setNegativeButton(R.string.action_cancel) { _, _ ->
+                callback.onImportPasswordDialogNegativeButtonClicked()
+            }
+
+        // Only show dialog title if screen size is under a certain dimension.
+        // Otherwise it becomes much harder to type text, see #53.
+        val dimen = context.resources.getDimension(R.dimen.label_edit_dialog_title_min_height) /
+                context.resources.displayMetrics.density
+        if (context.resources.configuration.screenHeightDp >= dimen) {
+            builder.setTitle(R.string.encrypted_import_dialog_title)
+        }
+
+        val dialog = builder.create()
+        dialog.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE)
+        dialog.setCanceledOnTouchOutside(true)
+
+        showPasswordCheckbox.setOnCheckedChangeListener { _, isChecked ->
+            val transformationMethod = if (isChecked) null else PasswordTransformationMethod()
+            passwordInput.transformationMethod = transformationMethod
+        }
+
+        // Cursor must be hidden when dialog is dismissed to prevent memory leak
+        // See [https://stackoverflow.com/questions/36842805/dialogfragment-leaking-memory]
+        dialog.setOnDismissListener {
+            passwordInput.isCursorVisible = false
+        }
+
+        passwordInput.doAfterTextChanged {
+            val okBtn = dialog.getButton(DialogInterface.BUTTON_POSITIVE)
+            okBtn.isEnabled = it?.isNotEmpty() ?: false
+            viewModel.onPasswordChanged(it?.toString() ?: "")
+        }
+
+        passwordInput.requestFocus()
+        viewModel.setDialogDataEvent.observeEvent(this) { password ->
+            passwordInput.setText(password)
+        }
+
+        viewModel.start()
+
+        return dialog
+    }
+
+    override fun onCancel(dialog: DialogInterface) {
+        super.onCancel(dialog)
+        callback.onImportPasswordDialogCancelled()
+    }
+
+    private val callback: Callback
+        get() = (parentFragment as? Callback)
+            ?: (activity as? Callback)
+            ?: error("No callback for ImportPasswordDialog")
+
+    interface Callback {
+        fun onImportPasswordDialogPositiveButtonClicked(password: String) = Unit
+        fun onImportPasswordDialogNegativeButtonClicked() = Unit
+        fun onImportPasswordDialogCancelled() = Unit
+    }
+
+    companion object {
+        fun newInstance(): ImportPasswordDialog {
+            return ImportPasswordDialog()
+        }
+    }
+}

--- a/app/src/main/kotlin/com/maltaisn/notes/ui/settings/ImportPasswordDialog.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/ui/settings/ImportPasswordDialog.kt
@@ -10,8 +10,8 @@ import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.DialogFragment
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.maltaisn.notes.App
-import com.maltaisn.notes.sync.R
-import com.maltaisn.notes.sync.databinding.DialogImportPasswordBinding
+import com.maltaisn.notes.R
+import com.maltaisn.notes.databinding.DialogImportPasswordBinding
 import com.maltaisn.notes.ui.observeEvent
 import com.maltaisn.notes.ui.viewModel
 import javax.inject.Inject

--- a/app/src/main/kotlin/com/maltaisn/notes/ui/settings/ImportPasswordViewModel.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/ui/settings/ImportPasswordViewModel.kt
@@ -1,0 +1,46 @@
+package com.maltaisn.notes.ui.settings
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import com.maltaisn.notes.ui.AssistedSavedStateViewModelFactory
+import com.maltaisn.notes.ui.Event
+import com.maltaisn.notes.ui.send
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+
+class ImportPasswordViewModel @AssistedInject constructor(
+    @Assisted private val savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val _setDialogDataEvent = MutableLiveData<Event<String>>()
+    val setDialogDataEvent: LiveData<Event<String>>
+        get() = _setDialogDataEvent
+
+    private var password = savedStateHandle[KEY_PASSWORD] ?: ""
+        set(value) {
+            field = value
+            savedStateHandle[KEY_PASSWORD] = value
+        }
+
+    fun onPasswordChanged(password: String) {
+        this.password = password
+    }
+
+    fun start() {
+        if (KEY_PASSWORD in savedStateHandle) {
+            _setDialogDataEvent.send(this.password)
+        }
+    }
+
+    @AssistedFactory
+    interface Factory : AssistedSavedStateViewModelFactory<ImportPasswordViewModel> {
+        override fun create(savedStateHandle: SavedStateHandle): ImportPasswordViewModel
+    }
+
+    companion object {
+        private const val KEY_PASSWORD = "password"
+    }
+}

--- a/app/src/main/kotlin/com/maltaisn/notes/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/ui/settings/SettingsViewModel.kt
@@ -27,8 +27,8 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.maltaisn.notes.R
-import com.maltaisn.notes.model.DefaultJsonManager.ImportResult
 import com.maltaisn.notes.model.JsonManager
+import com.maltaisn.notes.model.JsonManager.ImportResult
 import com.maltaisn.notes.model.LabelsRepository
 import com.maltaisn.notes.model.NotesRepository
 import com.maltaisn.notes.model.PrefsManager
@@ -174,10 +174,11 @@ class SettingsViewModel @AssistedInject constructor(
             ImportResult.BAD_DATA -> R.string.import_bad_data
             ImportResult.FUTURE_VERSION -> R.string.import_future_version
             ImportResult.KEY_MISSING_OR_INCORRECT -> {
-                if (Build.VERSION.SDK_INT >= 26)
+                if (Build.VERSION.SDK_INT >= 26) {
                     R.string.encrypted_import_key_error
-                else
+                } else {
                     R.string.encrypted_import_encryption_unsupported
+                }
             }
             ImportResult.SUCCESS -> R.string.import_success
         })

--- a/app/src/main/kotlin/com/maltaisn/notes/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/ui/settings/SettingsViewModel.kt
@@ -16,8 +16,14 @@
 
 package com.maltaisn.notes.ui.settings
 
+import android.os.Build
+import android.security.keystore.KeyProperties
+import android.security.keystore.KeyProtection
+import android.util.Base64
+import androidx.annotation.RequiresApi
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.maltaisn.notes.R
@@ -27,20 +33,30 @@ import com.maltaisn.notes.model.LabelsRepository
 import com.maltaisn.notes.model.NotesRepository
 import com.maltaisn.notes.model.PrefsManager
 import com.maltaisn.notes.model.ReminderAlarmManager
+import com.maltaisn.notes.ui.AssistedSavedStateViewModelFactory
 import com.maltaisn.notes.ui.Event
 import com.maltaisn.notes.ui.send
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.io.InputStream
 import java.io.OutputStream
-import javax.inject.Inject
+import java.security.KeyStore
+import java.security.SecureRandom
+import javax.crypto.SecretKey
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.PBEKeySpec
+import javax.crypto.spec.SecretKeySpec
 
-class SettingsViewModel @Inject constructor(
+class SettingsViewModel @AssistedInject constructor(
     private val notesRepository: NotesRepository,
     private val labelsRepository: LabelsRepository,
     private val prefsManager: PrefsManager,
     private val jsonManager: JsonManager,
     private val reminderAlarmManager: ReminderAlarmManager,
+    @Assisted private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
     private val _messageEvent = MutableLiveData<Event<Int>>()
@@ -55,13 +71,29 @@ class SettingsViewModel @Inject constructor(
     val releasePersistableUriEvent: LiveData<Event<String>>
         get() = _releasePersistableUriEvent
 
+    private val _showImportPasswordDialogEvent = MutableLiveData<Event<Unit>>()
+    val showImportPasswordDialogEvent: LiveData<Event<Unit>>
+        get() = _showImportPasswordDialogEvent
+
+    private var importJsonData = savedStateHandle[KEY_IMPORTED_JSON_DATA] ?: ""
+        set(value) {
+            field = value
+            savedStateHandle[KEY_IMPORTED_JSON_DATA] = value
+        }
+
     init {
         _lastAutoExport.value = prefsManager.lastAutoExportTime
     }
 
     fun exportData(output: OutputStream) {
         viewModelScope.launch(Dispatchers.IO) {
-            val jsonData = jsonManager.exportJsonData()
+            val jsonData = try {
+                jsonManager.exportJsonData()
+            } catch (e: Exception) {
+                showMessage(R.string.export_serialization_fail)
+                return@launch
+            }
+
             try {
                 output.use {
                     // bufferedWriter().write fails here for some reason...
@@ -77,7 +109,13 @@ class SettingsViewModel @Inject constructor(
     fun setupAutoExport(output: OutputStream, uri: String) {
         prefsManager.autoExportUri = uri
         viewModelScope.launch(Dispatchers.IO) {
-            val jsonData = jsonManager.exportJsonData()
+            val jsonData = try {
+                jsonManager.exportJsonData()
+            } catch (e: Exception) {
+                showMessage(R.string.export_serialization_fail)
+                return@launch
+            }
+
             try {
                 output.use {
                     output.write(jsonData.toByteArray())
@@ -107,13 +145,88 @@ class SettingsViewModel @Inject constructor(
                 return@launch
             }
             val result = jsonManager.importJsonData(jsonData)
-            showMessage(when (result) {
-                ImportResult.BAD_FORMAT -> R.string.import_bad_format
-                ImportResult.BAD_DATA -> R.string.import_bad_data
-                ImportResult.FUTURE_VERSION -> R.string.import_future_version
-                ImportResult.SUCCESS -> R.string.import_success
-            })
+            if (result == ImportResult.KEY_MISSING_OR_INCORRECT && Build.VERSION.SDK_INT >= 26) {
+                // Show dialog for user to enter encryption password
+                _showImportPasswordDialogEvent.postValue(Event(Unit))
+                importJsonData = jsonData
+            } else {
+                // Show result in case the imported file was not encrypted
+                showImportResultMessage(result)
+            }
         }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.M)
+    fun importSavedEncryptedJsonData(password: String) {
+        viewModelScope.launch(Dispatchers.IO) {
+            val salt = Base64.decode(prefsManager.encryptedImportKeyDerivationSalt, BASE64_FLAGS)
+            val decryptionKey = deriveKey(password, salt)
+
+            val result = jsonManager.importJsonData(importJsonData, decryptionKey)
+            importJsonData = ""
+            showImportResultMessage(result)
+        }
+    }
+
+    private fun showImportResultMessage(result: ImportResult) {
+        showMessage(when (result) {
+            ImportResult.BAD_FORMAT -> R.string.import_bad_format
+            ImportResult.BAD_DATA -> R.string.import_bad_data
+            ImportResult.FUTURE_VERSION -> R.string.import_future_version
+            ImportResult.KEY_MISSING_OR_INCORRECT -> {
+                if (Build.VERSION.SDK_INT >= 26)
+                    R.string.encrypted_import_key_error
+                else
+                    R.string.encrypted_import_encryption_unsupported
+            }
+            ImportResult.SUCCESS -> R.string.import_success
+        })
+    }
+
+    @RequiresApi(Build.VERSION_CODES.M)
+    fun generateExportKeyFromPassword(password: String) {
+        viewModelScope.launch(Dispatchers.IO) {
+            // Generate salt
+            val secureRandom = SecureRandom()
+            val salt = ByteArray(128)
+            secureRandom.nextBytes(salt)
+            // Save salt for later use
+            prefsManager.encryptedExportKeyDerivationSalt = Base64.encodeToString(salt, BASE64_FLAGS)
+
+            // Derive key
+            val aesKey = deriveKey(password, salt)
+
+            // Store key in Android KeyStore
+            val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE)
+            keyStore.load(null)
+            keyStore.setEntry(
+                EXPORT_ENCRYPTION_KEY_ALIAS,
+                KeyStore.SecretKeyEntry(aesKey),
+                KeyProtection.Builder(KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT)
+                    .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                    .build()
+            )
+            showMessage(R.string.encrypted_export_key_generation_successful)
+        }
+    }
+
+    fun deleteExportKey() {
+        viewModelScope.launch(Dispatchers.IO) {
+            val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE)
+            keyStore.load(null)
+            keyStore.deleteEntry(EXPORT_ENCRYPTION_KEY_ALIAS)
+            showMessage(R.string.encrypted_export_key_deletion_successful)
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.M)
+    private fun deriveKey(password: String, salt: ByteArray): SecretKey {
+        val keySpec = PBEKeySpec(password.toCharArray(), salt, PBKDF2_ITERATIONS, PBKDF2_KEY_LENGTH)
+        val secretKeyFactory = SecretKeyFactory.getInstance(KEY_DERIVATION_ALGORITHM)
+        val secretKey = secretKeyFactory.generateSecret(keySpec)
+
+        return SecretKeySpec(secretKey.encoded, KeyProperties.KEY_ALGORITHM_AES)
     }
 
     fun clearData() {
@@ -127,5 +240,20 @@ class SettingsViewModel @Inject constructor(
 
     private fun showMessage(messageId: Int) {
         _messageEvent.postValue(Event(messageId))
+    }
+
+    @AssistedFactory
+    interface Factory : AssistedSavedStateViewModelFactory<SettingsViewModel> {
+        override fun create(savedStateHandle: SavedStateHandle): SettingsViewModel
+    }
+
+    companion object {
+        private const val KEY_IMPORTED_JSON_DATA = "importedJsonData"
+        private const val ANDROID_KEYSTORE = "AndroidKeyStore"
+        private const val BASE64_FLAGS = Base64.NO_WRAP or Base64.NO_PADDING
+        private const val EXPORT_ENCRYPTION_KEY_ALIAS = "export_key"
+        private const val KEY_DERIVATION_ALGORITHM = "PBKDF2withHmacSHA512"
+        private const val PBKDF2_ITERATIONS = 120000
+        private const val PBKDF2_KEY_LENGTH = 256
     }
 }

--- a/app/src/main/kotlin/com/maltaisn/notes/ui/sort/SortDialog.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/ui/sort/SortDialog.kt
@@ -18,7 +18,6 @@ package com.maltaisn.notes.ui.sort
 
 import android.app.Dialog
 import android.os.Bundle
-import android.view.LayoutInflater
 import androidx.fragment.app.DialogFragment
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.maltaisn.notes.App
@@ -52,7 +51,7 @@ class SortDialog : DialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val context = requireContext()
-        val binding = DialogSortBinding.inflate(LayoutInflater.from(context), null, false)
+        val binding = DialogSortBinding.inflate(layoutInflater, null, false)
 
         // Create dialog
         val dialog = MaterialAlertDialogBuilder(context)

--- a/app/src/main/res/layout/dialog_export_password.xml
+++ b/app/src/main/res/layout/dialog_export_password.xml
@@ -1,0 +1,83 @@
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingTop="8dp"
+    app:backgroundInsetBottom="30dp"
+    app:backgroundInsetTop="30dp"
+    >
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingTop="8dp"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        >
+
+        <!-- The dialog is unusable in landscape mode
+             with keyboard shown, but there's not much to do about it. -->
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/password_input_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:errorEnabled="true"
+            >
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/password_input"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="16dp"
+                android:paddingBottom="16dp"
+                android:imeOptions="actionNext"
+                android:singleLine="true"
+                android:maxLines="1"
+                android:nextFocusDown="@id/password_repeat"
+                android:textDirection="anyRtl"
+                android:hint="@string/encrypted_export_password"
+                android:inputType="textPassword"
+                tools:text="Password"
+                />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/password_repeat_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            app:errorEnabled="true"
+            >
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/password_repeat"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="16dp"
+                android:paddingBottom="16dp"
+                android:imeOptions="actionDone"
+                android:singleLine="true"
+                android:maxLines="1"
+                android:nextFocusDown="@android:id/button1"
+                android:textDirection="anyRtl"
+                android:hint="@string/encrypted_export_repeat_password"
+                android:inputType="textPassword"
+                tools:text="Repeat Password"
+                />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <CheckBox
+            android:id="@+id/show_password_chk"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/encrypted_export_show_password"
+            android:textAlignment="viewStart"
+            />
+
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/dialog_export_password.xml
+++ b/app/src/main/res/layout/dialog_export_password.xml
@@ -1,3 +1,19 @@
+<!--
+  Copyright 2023 Nicolas Maltais
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
 <ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -26,6 +42,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:errorEnabled="true"
+            app:passwordToggleEnabled="true"
             >
 
             <com.google.android.material.textfield.TextInputEditText
@@ -49,8 +66,8 @@
             android:id="@+id/password_repeat_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
             app:errorEnabled="true"
+            app:passwordToggleEnabled="true"
             >
 
             <com.google.android.material.textfield.TextInputEditText
@@ -69,15 +86,6 @@
                 tools:text="Repeat Password"
                 />
         </com.google.android.material.textfield.TextInputLayout>
-
-        <CheckBox
-            android:id="@+id/show_password_chk"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:text="@string/encrypted_export_show_password"
-            android:textAlignment="viewStart"
-            />
 
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/dialog_import_password.xml
+++ b/app/src/main/res/layout/dialog_import_password.xml
@@ -1,0 +1,57 @@
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingTop="8dp"
+    app:backgroundInsetBottom="30dp"
+    app:backgroundInsetTop="30dp"
+    >
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingTop="8dp"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        >
+
+        <!-- The dialog is unusable in landscape mode
+             with keyboard shown, but there's not much to do about it. -->
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/password_input_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            >
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/password_input"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="16dp"
+                android:paddingBottom="16dp"
+                android:imeOptions="actionNext"
+                android:singleLine="true"
+                android:maxLines="1"
+                android:nextFocusDown="@android:id/button1"
+                android:textDirection="anyRtl"
+                android:hint="@string/encrypted_export_password"
+                android:inputType="textPassword"
+                tools:text="Password"
+                />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <CheckBox
+            android:id="@+id/show_password_chk"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/encrypted_export_show_password"
+            android:textAlignment="viewStart"
+            />
+
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/dialog_import_password.xml
+++ b/app/src/main/res/layout/dialog_import_password.xml
@@ -1,3 +1,19 @@
+<!--
+  Copyright 2023 Nicolas Maltais
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
 <ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -9,49 +25,31 @@
     app:backgroundInsetTop="30dp"
     >
 
-    <LinearLayout
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/password_input_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
         android:paddingTop="8dp"
         android:paddingStart="16dp"
         android:paddingEnd="16dp"
+        app:passwordToggleEnabled="true"
         >
 
-        <!-- The dialog is unusable in landscape mode
-             with keyboard shown, but there's not much to do about it. -->
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/password_input_layout"
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/password_input"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            >
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/password_input"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:paddingTop="16dp"
-                android:paddingBottom="16dp"
-                android:imeOptions="actionNext"
-                android:singleLine="true"
-                android:maxLines="1"
-                android:nextFocusDown="@android:id/button1"
-                android:textDirection="anyRtl"
-                android:hint="@string/encrypted_export_password"
-                android:inputType="textPassword"
-                tools:text="Password"
-                />
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <CheckBox
-            android:id="@+id/show_password_chk"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:text="@string/encrypted_export_show_password"
-            android:textAlignment="viewStart"
+            android:paddingTop="16dp"
+            android:paddingBottom="16dp"
+            android:imeOptions="actionDone"
+            android:singleLine="true"
+            android:maxLines="1"
+            android:nextFocusDown="@android:id/button1"
+            android:textDirection="anyRtl"
+            android:hint="@string/encrypted_export_password"
+            android:inputType="textPassword"
+            tools:text="Password"
             />
+    </com.google.android.material.textfield.TextInputLayout>
 
-    </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  Copyright 2021 Nicolas Maltais
+  Copyright 2023 Nicolas Maltais
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@
 
     <dimen name="reminder_dialog_max_width">500dp</dimen>
 
-    <!-- Minimum screen height to show title for LabelEditDialog. -->
-    <dimen name="label_edit_dialog_title_min_height">420dp</dimen>
+    <!-- Minimum screen height to show title for dialogs with a text input. -->
+    <dimen name="input_dialog_title_min_height">420dp</dimen>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2022 Nicolas Maltais
+  Copyright 2023 Nicolas Maltais
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -205,7 +205,8 @@
     <string name="pref_data_export">Export data</string>
     <string name="pref_data_export_summary">Export notes data as JSON</string>
     <string name="pref_data_encrypted_export">Encrypted export</string>
-    <string name="pref_data_encrypted_export_summary">Encrypts the exported notes with AES-256GCM. Access is not possible without the correct password.</string>
+    <string name="pref_data_encrypted_export_summary">Encrypts the exported notes. Access is not possible without
+        the correct password.</string>
     <string name="pref_data_auto_export">Automatic data export</string>
     <string name="pref_data_auto_export_summary">Automatically export the app\'s data to a file, once a day.</string>
     <string name="pref_data_auto_export_date">(Last exported on %s)</string>
@@ -222,16 +223,17 @@
     <string name="pref_about_version">Version</string>
 
     <string name="pref_restart_dialog_title">Restart required!</string>
-    <string name="pref_restart_dialog_description">A restart is required for these changes to take effect. Do you want to restart the app now?</string>
+    <string name="pref_restart_dialog_description">A restart is required for these changes to take effect.
+        Do you want to restart the app now?</string>
 
     <!-- Import/export data messages -->
     <string name="export_success">Data exported successfully!</string>
     <string name="export_fail">An error occurred during data export.</string>
-    <string name="export_serialization_fail">An error occurred during data export. Try disabling encryption and try again.</string>
-    <string name="encrypted_export_dialog_title">Set Password</string>
+    <string name="export_serialization_fail">An error occurred during data export.
+        Try disabling encryption and try again.</string>
+    <string name="encrypted_export_dialog_title">Set password</string>
     <string name="encrypted_export_password">Password</string>
-    <string name="encrypted_export_repeat_password">Confirm Password</string>
-    <string name="encrypted_export_show_password">Show password</string>
+    <string name="encrypted_export_repeat_password">Confirm password</string>
     <string name="encrypted_export_password_matching_error">Passwords do not match</string>
     <string name="encrypted_export_key_generation_successful">Encryption enabled successfully!</string>
     <string name="encrypted_export_key_deletion_successful">Encryption disabled successfully!</string>
@@ -243,8 +245,10 @@
     <string name="import_bad_data">Could not import data, some fields have invalid values.
         This can happen if importing data from a later version, try updating the app.</string>
     <string name="encrypted_import_dialog_title">Enter Password</string>
-    <string name="encrypted_import_key_error">An error occurred while attempting to decrypt this file. Check if the password was correct.</string>
-    <string name="encrypted_import_encryption_unsupported">Could not import data, encryption is not supported on this version of Android.</string>
+    <string name="encrypted_import_key_error">An error occurred while attempting to decrypt this file.
+        Check if the password was correct.</string>
+    <string name="encrypted_import_encryption_unsupported">Could not import data, encryption is not supported
+        on this version of Android.</string>
     <string name="auto_export_message">To enable automatic export, a file must be chosen to
         save the data. The app\'s data will be exported once a day while the app is opened.
         Click OK to proceed.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -204,6 +204,8 @@
     <string name="pref_group_data">Data</string>
     <string name="pref_data_export">Export data</string>
     <string name="pref_data_export_summary">Export notes data as JSON</string>
+    <string name="pref_data_encrypted_export">Encrypted export</string>
+    <string name="pref_data_encrypted_export_summary">Encrypts the exported notes with AES-256GCM. Access is not possible without the correct password.</string>
     <string name="pref_data_auto_export">Automatic data export</string>
     <string name="pref_data_auto_export_summary">Automatically export the app\'s data to a file, once a day.</string>
     <string name="pref_data_auto_export_date">(Last exported on %s)</string>
@@ -225,6 +227,14 @@
     <!-- Import/export data messages -->
     <string name="export_success">Data exported successfully!</string>
     <string name="export_fail">An error occurred during data export.</string>
+    <string name="export_serialization_fail">An error occurred during data export. Try disabling encryption and try again.</string>
+    <string name="encrypted_export_dialog_title">Set Password</string>
+    <string name="encrypted_export_password">Password</string>
+    <string name="encrypted_export_repeat_password">Confirm Password</string>
+    <string name="encrypted_export_show_password">Show password</string>
+    <string name="encrypted_export_password_matching_error">Passwords do not match</string>
+    <string name="encrypted_export_key_generation_successful">Encryption enabled successfully!</string>
+    <string name="encrypted_export_key_deletion_successful">Encryption disabled successfully!</string>
     <string name="import_success">Data imported successfully!</string>
     <string name="import_future_version">Data imported successfully! Note that some information may
         have been lost because the data originates from a later version.</string>
@@ -232,6 +242,9 @@
     <string name="import_bad_format">Could not import data, JSON data is invalid.</string>
     <string name="import_bad_data">Could not import data, some fields have invalid values.
         This can happen if importing data from a later version, try updating the app.</string>
+    <string name="encrypted_import_dialog_title">Enter Password</string>
+    <string name="encrypted_import_key_error">An error occurred while attempting to decrypt this file. Check if the password was correct.</string>
+    <string name="encrypted_import_encryption_unsupported">Could not import data, encryption is not supported on this version of Android.</string>
     <string name="auto_export_message">To enable automatic export, a file must be chosen to
         save the data. The app\'s data will be exported once a day while the app is opened.
         Click OK to proceed.</string>

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -46,11 +46,11 @@
 
         <SeekBarPreference
             android:defaultValue="2"
-            app:key="preview_labels"
-            app:title="@string/pref_preview_labels"
-            app:min="0"
             android:max="10"
+            app:key="preview_labels"
+            app:min="0"
             app:showSeekBarValue="true"
+            app:title="@string/pref_preview_labels"
             />
 
         <DropDownPreference
@@ -63,9 +63,9 @@
             />
 
         <Preference
+            android:summary="@string/pref_preview_lines_summary"
             app:key="preview_lines"
             app:title="@string/pref_preview_lines"
-            android:summary="@string/pref_preview_lines_summary"
             />
 
     </PreferenceCategory>
@@ -105,6 +105,13 @@
             app:key="export_data"
             app:summary="@string/pref_data_export_summary"
             app:title="@string/pref_data_export"
+            />
+
+        <SwitchPreferenceCompat
+            android:title="@string/pref_data_encrypted_export"
+            app:defaultValue="false"
+            app:key="encrypted_export"
+            app:summary="@string/pref_data_encrypted_export_summary"
             />
 
         <SwitchPreferenceCompat

--- a/sharedTest/src/main/kotlin/com/maltaisn/notesshared/TestDateExtensions.kt
+++ b/sharedTest/src/main/kotlin/com/maltaisn/notesshared/TestDateExtensions.kt
@@ -16,17 +16,18 @@
 
 package com.maltaisn.notesshared
 
+import android.os.Build
 import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
 
-val datePatterns = listOf(
+var datePatterns = listOf(
     DatePattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", TimeZone.getTimeZone("GMT"), 24),
     DatePattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", null, null),
     DatePattern("yyyy-MM-dd'T'HH:mm:ss.SSS", TimeZone.getDefault(), 23),
-    DatePattern("yyyy-MM-dd", TimeZone.getDefault(), 10)
+    DatePattern("yyyy-MM-dd", TimeZone.getTimeZone("GMT"), 10)
 )
 
 data class DatePattern(val pattern: String, val timeZone: TimeZone?, val length: Int?)
@@ -43,6 +44,10 @@ fun dateFor(date: String): Date {
     val dateFormat = SimpleDateFormat("", Locale.US)
     for (pattern in datePatterns) {
         if (pattern.length == null || date.length == pattern.length) {
+            // Pattern character 'X' is only supported starting from API 24
+            if (Build.VERSION.SDK_INT < 24 && pattern.pattern.contains("X")) {
+                continue
+            }
             if (pattern.timeZone != null) {
                 dateFormat.timeZone = pattern.timeZone
             }


### PR DESCRIPTION
As requested in #29 and #52 this implements the option for users to protect the exported data using a password. 

# Implementation Details
PBKDF2-SHA512 with 120.000 iterations and a random 128 bit salt is used to derive a 256 bit key from the user's password. The data is then encrypted using AES256 in GCM mode. The encrypted backup, which is still a JSON file, now contains the ciphertext itself,  the GCM nonce / iv which is needed for decryption and the salt which has been used for key generation. All of these values are stored Base64 encoded so that the file remains human readable, even if the raw bytes contain unprintable characters.

After enabling encrypted backups and setting a password for the first time, the key is securely stored within the Android KeyStore, so that it can be retrieved without the user having to enter his password every time a backup is created. As a result, automatic data export still works as expected. When disabling encryption, the key gets deleted from the KeyStore.

Upon importing an encrypted backup, the user is prompted for the corresponding password. This password is then used in combination with the salt from the file to once again derive the encryption key using PBKDF2. If the password is correct, the same key will be derived and decryption succeeds.

The structure of the exported JSON file has been adjusted so that encrypted data as well as unencrypted data is supported. Users can still choose to use unencrypted exports and importing unencrypted data also works just like normal.

One thing to note is that due to the changes to the file format, older backup files cannot be imported and will result in `ImportResult.BAD_DATA`.

# Version Compatibility
As of right now, this feature is only enabled on API levels >= 26. The key derivation algorithm `PBKDF2withHmacSHA512` isn't available on earlier API levels (see https://developer.android.com/reference/javax/crypto/SecretKeyFactory) and I didn't want to fall back to using `PBKDF2withHmacSHA1` or similar. 

It would be possible to implement `PBKDF2withHmacSHA512` directly within the app though since all needed cryptographic primitives are available even in earlier APIs, but I'm not sure if that's worth doing. This would allow encryption to work on all devices with API level >= 23.

Older versions don't support storing AES keys within the Android KeyStore and the workaround would be pretty ugly. One way to achieve this would be to encrypt the AES key using RSA, storing the RSA private key in the KeyStore and storing the encrypted AES key for example in a shared preference.

# Development Status
This version is functional as far as I can tell and should hopefully include much less memory leaks compared to my Material 3 PR. :)

I marked this as work in progress since the existing tests within `DefaultJsonManagerTest.kt` still need to be updated and extended to also cover encrypted imports / exports. Some additional unit tests for the newly created methods in  the SettingsViewModel should probably be added too.

Right now I'm still working on getting unit tests to execute at all. Might be due to the changes in 761c5c4b05d73a08d822fd1ac7585cb844b24d80. I'm not sure. Do unit tests work for you?