### PR TITLE
Fix Permissions Check #AlarmReceiver #001

### DIFF
--- a/app/src/main/kotlin/com/maltaisn/notes/receiver/AlarmReceiver.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/receiver/AlarmReceiver.kt
@@ -16,11 +16,14 @@
 
 package com.maltaisn.notes.receiver
 
+import android.Manifest
 import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Build
+import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.maltaisn.notes.App
@@ -117,6 +120,20 @@ class AlarmReceiver : BroadcastReceiver() {
                 PendingIntent.getActivity(context, noteId.toInt(), postponeIntent, pendingIntentFlags))
         }
 
+        if (ActivityCompat.checkSelfPermission(
+                context,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            // TODO: Consider calling
+            //    ActivityCompat#requestPermissions
+            // here to request the missing permissions, and then overriding
+            //   public void onRequestPermissionsResult(int requestCode, String[] permissions,
+            //                                          int[] grantResults)
+            // to handle the case where the user grants the permission. See the documentation
+            // for ActivityCompat#requestPermissions for more details.
+            return
+        }
         NotificationManagerCompat.from(context).notify(noteId.toInt(), builder.build())
     }
 


### PR DESCRIPTION
## Fix permissions check in Notification manager code
* I see that we have an error in AlarmReceiver Activity in Notification manager code because the permissions check code not added, so i just add the code to fix this problem, I hope this contribution will help our project to be better then old.