### PR TITLE
Add ZIP archive option for automatic export

### DIFF
--- a/app/src/main/kotlin/com/maltaisn/notes/model/AutoExportFormat.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/model/AutoExportFormat.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Nicolas Maltais
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.maltaisn.notes.model
+
+import com.maltaisn.notes.R
+
+/**
+ * Enum for automatic export output formats.
+ * [value] is from [R.array.pref_auto_export_format_values].
+ */
+enum class AutoExportFormat(override val value: String) : ValueEnum<String> {
+    JSON("json"),
+    ZIP("zip");
+
+    companion object {
+        fun fromValue(value: String): AutoExportFormat = findValueEnum(value)
+    }
+}

--- a/app/src/main/kotlin/com/maltaisn/notes/model/DefaultPrefsManager.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/model/DefaultPrefsManager.kt
@@ -65,6 +65,7 @@ class DefaultPrefsManager @Inject constructor(
     override var encryptedImportKeyDerivationSalt: String by preference(ENCRYPTED_IMPORT_KEY_DERIVATION_SALT,
         "")
     override var shouldAutoExport: Boolean by preference(AUTO_EXPORT, false)
+    override var autoExportFormat: AutoExportFormat by enumPreference(AUTO_EXPORT_FORMAT, AutoExportFormat.JSON)
     override var autoExportUri: String by preference(AUTO_EXPORT_URI, "")
     override var autoExportFailed: Boolean by preference(AUTO_EXPORT_FAILED, false)
     override var lastAutoExportTime: Long by preference(LAST_AUTO_EXPORT_TIME, 0)
@@ -192,6 +193,7 @@ class DefaultPrefsManager @Inject constructor(
         const val ENCRYPTED_EXPORT = "encrypted_export"
         const val EXPORT_DATA = "export_data"
         const val AUTO_EXPORT = "auto_export"
+        const val AUTO_EXPORT_FORMAT = "auto_export_format"
         const val IMPORT_DATA = "import_data"
         const val EXPORT_ARCHIVE = "export_archive"
         const val CLEAR_DATA = "clear_data"
@@ -243,4 +245,3 @@ class DefaultPrefsManager @Inject constructor(
         const val MAXIMUM_RELATIVE_DATE_DAYS = 6
     }
 }
-

--- a/app/src/main/kotlin/com/maltaisn/notes/model/PrefsManager.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/model/PrefsManager.kt
@@ -53,6 +53,7 @@ interface PrefsManager {
     var encryptedExportKeyDerivationSalt: String
     var encryptedImportKeyDerivationSalt: String
     var shouldAutoExport: Boolean
+    var autoExportFormat: AutoExportFormat
     var autoExportUri: String
     var autoExportFailed: Boolean
     var lastAutoExportTime: Long
@@ -74,4 +75,3 @@ interface PrefsManager {
     @TestOnly
     fun clear(context: Context)
 }
-

--- a/app/src/main/kotlin/com/maltaisn/notes/ui/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/ui/main/MainActivity.kt
@@ -225,7 +225,7 @@ class MainActivity : AppCompatActivity(), NavController.OnDestinationChangedList
             } catch (e: Exception) {
                 Log.i(TAG, "Auto data export failed", e)
                 null
-            })
+            }, getString(R.string.edit_copy_untitled_name))
         }
 
         viewModel.createNoteEvent.observeEvent(this) { newNoteData ->

--- a/app/src/main/kotlin/com/maltaisn/notes/ui/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/ui/main/MainViewModel.kt
@@ -27,6 +27,8 @@ import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavDirections
 import com.maltaisn.notes.NavGraphMainDirections
 import com.maltaisn.notes.R
+import com.maltaisn.notes.model.ArchiveExporter
+import com.maltaisn.notes.model.AutoExportFormat
 import com.maltaisn.notes.model.DefaultPrefsManager
 import com.maltaisn.notes.model.JsonManager
 import com.maltaisn.notes.model.LabelsRepository
@@ -57,6 +59,7 @@ class MainViewModel @Inject constructor(
     private val labelsRepository: LabelsRepository,
     private val prefsManager: PrefsManager,
     private val jsonManager: JsonManager,
+    private val archiveExporter: ArchiveExporter,
     private val reminderAlarmManager: ReminderAlarmManager,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
@@ -231,13 +234,20 @@ class MainViewModel @Inject constructor(
         }
     }
 
-    fun autoExport(output: OutputStream?) {
+    fun autoExport(output: OutputStream?, untitledName: String) {
         if (output != null) {
             viewModelScope.launch(Dispatchers.IO) {
                 prefsManager.autoExportFailed = try {
-                    val jsonData = jsonManager.exportJsonData()
                     output.use {
-                        output.write(jsonData.toByteArray())
+                        when (prefsManager.autoExportFormat) {
+                            AutoExportFormat.JSON -> {
+                                val jsonData = jsonManager.exportJsonData()
+                                output.write(jsonData.toByteArray())
+                            }
+                            AutoExportFormat.ZIP -> {
+                                archiveExporter.exportArchive(output, untitledName)
+                            }
+                        }
                     }
                     prefsManager.lastAutoExportTime = System.currentTimeMillis()
                     false

--- a/app/src/main/kotlin/com/maltaisn/notes/ui/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/maltaisn/notes/ui/settings/SettingsFragment.kt
@@ -45,6 +45,7 @@ import com.maltaisn.notes.BuildConfig
 import com.maltaisn.notes.R
 import com.maltaisn.notes.TAG
 import com.maltaisn.notes.databinding.FragmentSettingsBinding
+import com.maltaisn.notes.model.AutoExportFormat
 import com.maltaisn.notes.model.DefaultPrefsManager
 import com.maltaisn.notes.navigateSafe
 import com.maltaisn.notes.setEnterExitTransitions
@@ -98,7 +99,7 @@ class SettingsFragment : PreferenceFragmentCompat(), ConfirmDialog.Callback, Exp
                 val output = try {
                     val cr = context.contentResolver
                     cr.takePersistableUriPermission(uri, Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
-                    cr.openOutputStream(uri)
+                    cr.openOutputStream(uri, "wt")
                 } catch (e: Exception) {
                     Log.i(TAG, "Data export failed", e)
                     null
@@ -254,6 +255,9 @@ class SettingsFragment : PreferenceFragmentCompat(), ConfirmDialog.Callback, Exp
             true
         }
 
+        requirePreference<DropDownPreference>(DefaultPrefsManager.AUTO_EXPORT_FORMAT)
+            .summaryProvider = DropDownPreference.SimpleSummaryProvider.getInstance()
+
         requirePreference<Preference>(DefaultPrefsManager.IMPORT_DATA).setOnPreferenceClickListener {
             // note: explicit mimetype fails for some devices, see #11
             val intent = Intent(Intent.ACTION_OPEN_DOCUMENT)
@@ -302,6 +306,22 @@ class SettingsFragment : PreferenceFragmentCompat(), ConfirmDialog.Callback, Exp
     private val autoExportPref: SwitchPreferenceCompat
         get() = requirePreference(DefaultPrefsManager.AUTO_EXPORT)
 
+    private val autoExportFormat: AutoExportFormat
+        get() = AutoExportFormat.fromValue(requirePreference<DropDownPreference>(
+            DefaultPrefsManager.AUTO_EXPORT_FORMAT).value)
+
+    private val autoExportExtension: String
+        get() = when (autoExportFormat) {
+            AutoExportFormat.JSON -> "json"
+            AutoExportFormat.ZIP -> "zip"
+        }
+
+    private val autoExportMimeType: String
+        get() = when (autoExportFormat) {
+            AutoExportFormat.JSON -> "application/json"
+            AutoExportFormat.ZIP -> "application/zip"
+        }
+
     private fun updateAutoExportSummary(enabled: Boolean, date: Long = 0) {
         if (enabled) {
             autoExportPref.summary = buildString {
@@ -328,8 +348,10 @@ class SettingsFragment : PreferenceFragmentCompat(), ConfirmDialog.Callback, Exp
 
             AUTOMATIC_EXPORT_DIALOG_TAG -> {
                 val intent = Intent(Intent.ACTION_CREATE_DOCUMENT)
-                    .setType("application/json")
-                    .addCategory(Intent.CATEGORY_OPENABLE)
+                    .setType(autoExportMimeType)
+                    .addCategory(Intent.CATEGORY_OPENABLE).apply {
+                        putExtra(Intent.EXTRA_TITLE, "notes.$autoExportExtension")
+                    }
                 autoExportLauncher?.launch(intent)
             }
 

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -75,4 +75,13 @@
         <item>365</item>
     </string-array>
 
+    <string-array name="pref_auto_export_format_entries">
+        <item>@string/pref_data_auto_export_format_json</item>
+        <item>@string/pref_data_auto_export_format_zip</item>
+    </string-array>
+    <string-array name="pref_auto_export_format_values">
+        <item>json</item>
+        <item>zip</item>
+    </string-array>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -230,12 +230,15 @@
     <string name="pref_data_encrypted_export_summary">Encrypts the exported notes. Access is not possible without
         the correct password.</string>
     <string name="pref_data_auto_export">Automatic data export</string>
-    <string name="pref_data_auto_export_summary">Automatically export the app\'s data to a file, once a day.</string>
+    <string name="pref_data_auto_export_summary">Automatically export notes to a file, once a day.</string>
     <string name="pref_data_auto_export_date">(Last exported on %s)</string>
+    <string name="pref_data_auto_export_format">Automatic export format</string>
+    <string name="pref_data_auto_export_format_json">JSON data</string>
+    <string name="pref_data_auto_export_format_zip">ZIP text archive</string>
     <string name="pref_data_import">Import data</string>
     <string name="pref_data_import_summary">Import previously exported JSON data, merging with existing data.</string>
     <string name="pref_data_export_archive">Export notes archive</string>
-    <string name="pref_data_export_archive_summary">Export notes as compressed ZIP archive (not automatic nor encrypted).</string>
+    <string name="pref_data_export_archive_summary">Export notes as compressed ZIP archive (not encrypted).</string>
     <string name="pref_data_clear">Clear all data</string>
     <string name="pref_data_clear_confirm_message">All notes data will be cleared permanently!
         This cannot be undone.</string>
@@ -273,9 +276,9 @@
     <string name="encrypted_import_encryption_unsupported">Could not import data, encryption is not supported
         on this version of Android.</string>
     <string name="auto_export_message">To enable automatic export, a file must be chosen to
-        save the data. The app\'s data will be exported once a day while the app is opened.
+        save the export. Notes will be exported once a day while the app is opened.
         Click OK to proceed.</string>
-    <string name="auto_export_fail">Failed to export data automatically. Make sure the export location
+    <string name="auto_export_fail">Failed to export automatically. Make sure the export location
         still exists and is accessible, then reconfigure automatic export.</string>
 
     <!-- Content description -->

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -161,6 +161,14 @@
             app:title="@string/pref_data_auto_export"
             />
 
+        <DropDownPreference
+            app:defaultValue="json"
+            app:entries="@array/pref_auto_export_format_entries"
+            app:entryValues="@array/pref_auto_export_format_values"
+            app:key="auto_export_format"
+            app:title="@string/pref_data_auto_export_format"
+            />
+
         <Preference
             app:icon="@drawable/ic_import"
             app:key="import_data"

--- a/app/src/test/kotlin/com/maltaisn/notes/ui/main/MainViewModelTest.kt
+++ b/app/src/test/kotlin/com/maltaisn/notes/ui/main/MainViewModelTest.kt
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2026 Nicolas Maltais
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.maltaisn.notes.ui.main
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.SavedStateHandle
+import com.maltaisn.notes.MainCoroutineRule
+import com.maltaisn.notes.model.ArchiveExporter
+import com.maltaisn.notes.model.AutoExportFormat
+import com.maltaisn.notes.model.JsonManager
+import com.maltaisn.notes.model.MockLabelsRepository
+import com.maltaisn.notes.model.MockNotesRepository
+import com.maltaisn.notes.model.PrefsManager
+import com.maltaisn.notes.model.ReminderAlarmManager
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import java.io.ByteArrayOutputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertContentEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class MainViewModelTest {
+
+    @get:Rule
+    var mainCoroutineRule = MainCoroutineRule()
+
+    @get:Rule
+    var instantExecutorRule = InstantTaskExecutorRule()
+
+    @Test
+    fun `should auto export json data`() {
+        var lastAutoExportTime = 0L
+        var autoExportFailed = true
+        val prefs: PrefsManager = mock {
+            on { shouldAutoExport } doReturn false
+            on { autoExportFormat } doReturn AutoExportFormat.JSON
+            on { lastAutoExportTime } doAnswer { lastAutoExportTime }
+            on { lastAutoExportTime = any() } doAnswer {
+                lastAutoExportTime = it.arguments[0] as Long
+            }
+            on { autoExportFailed = any() } doAnswer {
+                autoExportFailed = it.arguments[0] as Boolean
+            }
+        }
+        val output = CountingByteArrayOutputStream()
+        val viewModel = createViewModel(
+            prefs = prefs,
+            jsonManager = object : JsonManager {
+                override suspend fun exportJsonData() = "{\"notes\":[]}"
+                override suspend fun importJsonData(data: String, importKey: javax.crypto.SecretKey?) =
+                    JsonManager.ImportResult.SUCCESS
+            },
+        )
+
+        viewModel.autoExport(output, "Untitled")
+
+        assertTrue(output.closedLatch.await(2, TimeUnit.SECONDS))
+        assertContentEquals("{\"notes\":[]}".toByteArray(), output.toByteArray())
+        assertFalse(autoExportFailed)
+        assertTrue(lastAutoExportTime > 0)
+    }
+
+    @Test
+    fun `should auto export zip archive`() {
+        var lastAutoExportTime = 0L
+        var autoExportFailed = true
+        val prefs: PrefsManager = mock {
+            on { shouldAutoExport } doReturn false
+            on { autoExportFormat } doReturn AutoExportFormat.ZIP
+            on { lastAutoExportTime } doAnswer { lastAutoExportTime }
+            on { lastAutoExportTime = any() } doAnswer {
+                lastAutoExportTime = it.arguments[0] as Long
+            }
+            on { autoExportFailed = any() } doAnswer {
+                autoExportFailed = it.arguments[0] as Boolean
+            }
+        }
+        val output = CountingByteArrayOutputStream()
+        val viewModel = createViewModel(
+            prefs = prefs,
+            archiveExporter = object : ArchiveExporter {
+                override suspend fun exportArchive(output: java.io.OutputStream, untitledName: String) {
+                    output.write("ZIPDATA".toByteArray())
+                }
+            },
+        )
+
+        viewModel.autoExport(output, "Untitled")
+
+        assertTrue(output.closedLatch.await(2, TimeUnit.SECONDS))
+        assertContentEquals("ZIPDATA".toByteArray(), output.toByteArray())
+        assertFalse(autoExportFailed)
+        assertTrue(lastAutoExportTime > 0)
+    }
+
+    private fun createViewModel(
+        prefs: PrefsManager,
+        jsonManager: JsonManager = object : JsonManager {
+            override suspend fun exportJsonData() = ""
+            override suspend fun importJsonData(data: String, importKey: javax.crypto.SecretKey?) =
+                JsonManager.ImportResult.SUCCESS
+        },
+        archiveExporter: ArchiveExporter = object : ArchiveExporter {
+            override suspend fun exportArchive(output: java.io.OutputStream, untitledName: String) = Unit
+        },
+    ) = MainViewModel(
+        notesRepository = MockNotesRepository(MockLabelsRepository()),
+        labelsRepository = MockLabelsRepository(),
+        prefsManager = prefs,
+        jsonManager = jsonManager,
+        archiveExporter = archiveExporter,
+        reminderAlarmManager = object : ReminderAlarmManager {
+            override suspend fun updateAllAlarms() = Unit
+            override fun setNoteReminderAlarm(note: com.maltaisn.notes.model.entity.Note) = Unit
+            override suspend fun setNextNoteReminderAlarm(note: com.maltaisn.notes.model.entity.Note) = Unit
+            override suspend fun markReminderAsDone(noteId: Long) = Unit
+            override fun removeAlarm(noteId: Long) = Unit
+            override suspend fun removeAllAlarms() = Unit
+        },
+        savedStateHandle = SavedStateHandle(),
+    )
+
+    private class CountingByteArrayOutputStream : ByteArrayOutputStream() {
+        val closedLatch = CountDownLatch(1)
+
+        override fun close() {
+            super.close()
+            closedLatch.countDown()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add an automatic export format preference with JSON data and ZIP text archive options
- use the selected format when creating the automatic export document and during background exports
- add unit coverage for JSON and ZIP automatic export paths in MainViewModelTest

## Why
The app already supports exporting notes as a ZIP archive of text files manually, but automatic export is JSON-only. This adds a Syncthing-friendly one-way export option without changing the internal storage model.

## Testing
- added MainViewModelTest for JSON and ZIP automatic export flows
- local Gradle verification was attempted, but this environment still fails while generating gradle-api-8.13.jar in the Gradle cache before test execution starts